### PR TITLE
Issue #27: Error page middleware returns an empty body on OS X

### DIFF
--- a/src/Microsoft.AspNet.Diagnostics/ErrorPageMiddleware.cs
+++ b/src/Microsoft.AspNet.Diagnostics/ErrorPageMiddleware.cs
@@ -126,7 +126,7 @@ namespace Microsoft.AspNet.Diagnostics
             var stackTrace = ex.StackTrace;
             if (!string.IsNullOrEmpty(stackTrace))
             {
-                var heap = new Chunk { Text = stackTrace + Environment.NewLine, End = stackTrace.Length + 2 };
+                var heap = new Chunk { Text = stackTrace + Environment.NewLine, End = stackTrace.Length + Environment.NewLine.Length };
                 for (Chunk line = heap.Advance(Environment.NewLine); line.HasValue; line = heap.Advance(Environment.NewLine))
                 {
                     yield return StackFrame(line, showSource);


### PR DESCRIPTION
- Occurs on non windows system where Environment.NewLine is LF (1 symbol length) Unix, Linux, OS X etc. And options.ShowExceptionDetails is true.
- Number '2' (CR+LF length) is replaced by Environment.NewLine.Length.
#27
