### PR TITLE
Function name not passed to LoadFrame method when file name is not present in stacktrace

### DIFF
--- a/src/Microsoft.AspNet.Diagnostics/ErrorPageMiddleware.cs
+++ b/src/Microsoft.AspNet.Diagnostics/ErrorPageMiddleware.cs
@@ -142,7 +142,7 @@ namespace Microsoft.AspNet.Diagnostics
             int lineNumber = line.ToInt32();
 
             return string.IsNullOrEmpty(file)
-                ? LoadFrame(line.ToString(), string.Empty, 0, showSource)
+                ? LoadFrame(function, string.Empty, 0, showSource)
                 : LoadFrame(function, file, lineNumber, showSource);
         }
 


### PR DESCRIPTION
@Tratcher 

When file names are missing from exception stack trace the above line of code does not pass the detected function name. As a result issue described in bug : https://github.com/aspnet/Diagnostics/issues/49 happens.

This issue happens on mono. With this fix method names show up in the error page middleware output on mono.
