### PR TITLE
A regression introduced in a recent change

### DIFF
--- a/src/Microsoft.AspNet.Diagnostics/ErrorPageMiddleware.cs
+++ b/src/Microsoft.AspNet.Diagnostics/ErrorPageMiddleware.cs
@@ -142,7 +142,7 @@ namespace Microsoft.AspNet.Diagnostics
             int lineNumber = line.ToInt32();
 
             return string.IsNullOrEmpty(file)
-                ? LoadFrame(function, string.Empty, 0, showSource)
+                ? LoadFrame(string.IsNullOrEmpty(function) ? line.ToString() : function, string.Empty, 0, showSource)
                 : LoadFrame(function, file, lineNumber, showSource);
         }
 


### PR DESCRIPTION
With this fix a case is regressed.
https://github.com/aspnet/Diagnostics/commit/ba5d235a32dc2a2711404efc39149c990d713405

If file information is not available if function is empty then line needs to be sent. With the regression empty lines were printed in error page where symbol information is not available. This fixes it. Thanks Chris for identitying this and fixing.

@Tratcher 
