### PR TITLE
Additional logging to DatabaseErrorPageMiddleware

### DIFF
--- a/src/Microsoft.AspNet.Diagnostics.Entity/DatabaseErrorPageMiddleware.cs
+++ b/src/Microsoft.AspNet.Diagnostics.Entity/DatabaseErrorPageMiddleware.cs
@@ -66,9 +66,19 @@ namespace Microsoft.AspNet.Diagnostics.Entity
             {
                 try
                 {
-                    if (_loggerProvider.Logger.LastError.IsErrorLogged
-                        && _loggerProvider.Logger.LastError.Exception == ex)
+                    _logger.WriteVerbose(Strings.FormatDatabaseErrorPage_AttemptingToMatch(ex.GetType()));
+
+                    var isDatabaseError = _loggerProvider.Logger.LastError.IsErrorLogged
+                        && _loggerProvider.Logger.LastError.Exception == ex;
+
+                    if (!isDatabaseError)
                     {
+                        _logger.WriteVerbose(Strings.DatabaseErrorPage_NotMatched);
+                    }
+                    else
+                    {
+                        _logger.WriteVerbose(Strings.DatabaseErrorPage_Matched);
+
                         using (RequestServicesContainer.EnsureRequestServices(context, _serviceProvider))
                         {
                             var dbContextType = _loggerProvider.Logger.LastError.ContextType;
@@ -79,7 +89,11 @@ namespace Microsoft.AspNet.Diagnostics.Entity
                             }
                             else
                             {
-                                if (dbContext.Database is RelationalDatabase)
+                                if (!(dbContext.Database is RelationalDatabase))
+                                {
+                                    _logger.WriteVerbose(Strings.DatabaseErrorPage_NotRelationalDatabase);
+                                }
+                                else
                                 {
                                     var databaseExists = dbContext.Database.AsRelational().Exists();
 

--- a/src/Microsoft.AspNet.Diagnostics.Entity/Properties/Strings.Designer.cs
+++ b/src/Microsoft.AspNet.Diagnostics.Entity/Properties/Strings.Designer.cs
@@ -458,6 +458,70 @@ namespace Microsoft.AspNet.Diagnostics.Entity
             return GetString("DatabaseErrorPage_EnableMigrationsCommandsInfo");
         }
 
+        /// <summary>
+        /// {0} occurred, checking if Entity Framework recorded this exception as resulting from a failed database operation.
+        /// </summary>
+        internal static string DatabaseErrorPage_AttemptingToMatch
+        {
+            get { return GetString("DatabaseErrorPage_AttemptingToMatch"); }
+        }
+
+        /// <summary>
+        /// {0} occurred, checking if Entity Framework recorded this exception as resulting from a failed database operation.
+        /// </summary>
+        internal static string FormatDatabaseErrorPage_AttemptingToMatch(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("DatabaseErrorPage_AttemptingToMatch"), p0);
+        }
+
+        /// <summary>
+        /// Entity Framework recorded this exception was due to a failed database operation. Attempting to show database error page.
+        /// </summary>
+        internal static string DatabaseErrorPage_Matched
+        {
+            get { return GetString("DatabaseErrorPage_Matched"); }
+        }
+
+        /// <summary>
+        /// Entity Framework recorded this exception was due to a failed database operation. Attempting to show database error page.
+        /// </summary>
+        internal static string FormatDatabaseErrorPage_Matched()
+        {
+            return GetString("DatabaseErrorPage_Matched");
+        }
+
+        /// <summary>
+        /// Entity Framework did not record this exception. This means the exception is not a failed Entity Framework database operation, or the exception occurred from a DbContext that was not obtained from request services.
+        /// </summary>
+        internal static string DatabaseErrorPage_NotMatched
+        {
+            get { return GetString("DatabaseErrorPage_NotMatched"); }
+        }
+
+        /// <summary>
+        /// Entity Framework did not record this exception. This means the exception is not a failed Entity Framework database operation, or the exception occurred from a DbContext that was not obtained from request services.
+        /// </summary>
+        internal static string FormatDatabaseErrorPage_NotMatched()
+        {
+            return GetString("DatabaseErrorPage_NotMatched");
+        }
+
+        /// <summary>
+        /// The target data store is not a relational database. Skipping the database error page.
+        /// </summary>
+        internal static string DatabaseErrorPage_NotRelationalDatabase
+        {
+            get { return GetString("DatabaseErrorPage_NotRelationalDatabase"); }
+        }
+
+        /// <summary>
+        /// The target data store is not a relational database. Skipping the database error page.
+        /// </summary>
+        internal static string FormatDatabaseErrorPage_NotRelationalDatabase()
+        {
+            return GetString("DatabaseErrorPage_NotRelationalDatabase");
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNet.Diagnostics.Entity/Strings.resx
+++ b/src/Microsoft.AspNet.Diagnostics.Entity/Strings.resx
@@ -201,4 +201,16 @@
   <data name="DatabaseErrorPage_EnableMigrationsCommandsInfo" xml:space="preserve">
     <value>To use migrations from a command prompt you will need to &lt;a href='http://go.microsoft.com/fwlink/?LinkId=518242'&gt;install K Version Manager (KVM)&lt;/a&gt;. Once installed, you can run migration commands from a standard command prompt in the project directory.</value>
   </data>
+  <data name="DatabaseErrorPage_AttemptingToMatch" xml:space="preserve">
+    <value>{0} occurred, checking if Entity Framework recorded this exception as resulting from a failed database operation.</value>
+  </data>
+  <data name="DatabaseErrorPage_Matched" xml:space="preserve">
+    <value>Entity Framework recorded this exception was due to a failed database operation. Attempting to show database error page.</value>
+  </data>
+  <data name="DatabaseErrorPage_NotMatched" xml:space="preserve">
+    <value>Entity Framework did not record this exception. This means the exception is not a failed Entity Framework database operation, or the exception occurred from a DbContext that was not obtained from request services.</value>
+  </data>
+  <data name="DatabaseErrorPage_NotRelationalDatabase" xml:space="preserve">
+    <value>The target data store is not a relational database. Skipping the database error page.</value>
+  </data>
 </root>


### PR DESCRIPTION
I wanted this logging when I was debugging an issue with Identity not
showing the database error page.
