### PR TITLE
Handle wrapped exceptions in Database Error Page

### DIFF
--- a/src/Microsoft.AspNet.Diagnostics.Entity/Properties/Strings.Designer.cs
+++ b/src/Microsoft.AspNet.Diagnostics.Entity/Properties/Strings.Designer.cs
@@ -458,6 +458,86 @@ namespace Microsoft.AspNet.Diagnostics.Entity
             return GetString("DatabaseErrorPage_EnableMigrationsCommandsInfo");
         }
 
+        /// <summary>
+        /// {0} occurred, checking if Entity Framework recorded this exception as resulting from a failed database operation.
+        /// </summary>
+        internal static string DatabaseErrorPage_AttemptingToMatchException
+        {
+            get { return GetString("DatabaseErrorPage_AttemptingToMatchException"); }
+        }
+
+        /// <summary>
+        /// {0} occurred, checking if Entity Framework recorded this exception as resulting from a failed database operation.
+        /// </summary>
+        internal static string FormatDatabaseErrorPage_AttemptingToMatchException(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("DatabaseErrorPage_AttemptingToMatchException"), p0);
+        }
+
+        /// <summary>
+        /// Entity Framework recorded that the current exception was due to a failed database operation. Attempting to show database error page.
+        /// </summary>
+        internal static string DatabaseErrorPage_Matched
+        {
+            get { return GetString("DatabaseErrorPage_Matched"); }
+        }
+
+        /// <summary>
+        /// Entity Framework recorded that the current exception was due to a failed database operation. Attempting to show database error page.
+        /// </summary>
+        internal static string FormatDatabaseErrorPage_Matched()
+        {
+            return GetString("DatabaseErrorPage_Matched");
+        }
+
+        /// <summary>
+        /// Entity Framework did not record any exceptions due to failed database operations. This means the current exception is not a failed Entity Framework database operation, or the current exception occurred from a DbContext that was not obtained from request services.
+        /// </summary>
+        internal static string DatabaseErrorPage_NoRecordedException
+        {
+            get { return GetString("DatabaseErrorPage_NoRecordedException"); }
+        }
+
+        /// <summary>
+        /// Entity Framework did not record any exceptions due to failed database operations. This means the current exception is not a failed Entity Framework database operation, or the current exception occurred from a DbContext that was not obtained from request services.
+        /// </summary>
+        internal static string FormatDatabaseErrorPage_NoRecordedException()
+        {
+            return GetString("DatabaseErrorPage_NoRecordedException");
+        }
+
+        /// <summary>
+        /// The target data store is not a relational database. Skipping the database error page.
+        /// </summary>
+        internal static string DatabaseErrorPage_NotRelationalDatabase
+        {
+            get { return GetString("DatabaseErrorPage_NotRelationalDatabase"); }
+        }
+
+        /// <summary>
+        /// The target data store is not a relational database. Skipping the database error page.
+        /// </summary>
+        internal static string FormatDatabaseErrorPage_NotRelationalDatabase()
+        {
+            return GetString("DatabaseErrorPage_NotRelationalDatabase");
+        }
+
+        /// <summary>
+        /// The current exception (and its inner exceptions) do not match the last exception Entity Framework recorded due to a failed database operation. This means the database operation exception was handled and another exception occurred later in the request.
+        /// </summary>
+        internal static string DatabaseErrorPage_NoMatch
+        {
+            get { return GetString("DatabaseErrorPage_NoMatch"); }
+        }
+
+        /// <summary>
+        /// The current exception (and its inner exceptions) do not match the last exception Entity Framework recorded due to a failed database operation. This means the database operation exception was handled and another exception occurred later in the request.
+        /// </summary>
+        internal static string FormatDatabaseErrorPage_NoMatch()
+        {
+            return GetString("DatabaseErrorPage_NoMatch");
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNet.Diagnostics.Entity/Strings.resx
+++ b/src/Microsoft.AspNet.Diagnostics.Entity/Strings.resx
@@ -201,4 +201,19 @@
   <data name="DatabaseErrorPage_EnableMigrationsCommandsInfo" xml:space="preserve">
     <value>To use migrations from a command prompt you will need to &lt;a href='http://go.microsoft.com/fwlink/?LinkId=518242'&gt;install K Version Manager (KVM)&lt;/a&gt;. Once installed, you can run migration commands from a standard command prompt in the project directory.</value>
   </data>
+  <data name="DatabaseErrorPage_AttemptingToMatchException" xml:space="preserve">
+    <value>{0} occurred, checking if Entity Framework recorded this exception as resulting from a failed database operation.</value>
+  </data>
+  <data name="DatabaseErrorPage_Matched" xml:space="preserve">
+    <value>Entity Framework recorded that the current exception was due to a failed database operation. Attempting to show database error page.</value>
+  </data>
+  <data name="DatabaseErrorPage_NoRecordedException" xml:space="preserve">
+    <value>Entity Framework did not record any exceptions due to failed database operations. This means the current exception is not a failed Entity Framework database operation, or the current exception occurred from a DbContext that was not obtained from request services.</value>
+  </data>
+  <data name="DatabaseErrorPage_NotRelationalDatabase" xml:space="preserve">
+    <value>The target data store is not a relational database. Skipping the database error page.</value>
+  </data>
+  <data name="DatabaseErrorPage_NoMatch" xml:space="preserve">
+    <value>The current exception (and its inner exceptions) do not match the last exception Entity Framework recorded due to a failed database operation. This means the database operation exception was handled and another exception occurred later in the request.</value>
+  </data>
 </root>


### PR DESCRIPTION
If a database exception is wrapped later in the request (after EF has logged it) then we were not displaying the database error page.
This was occurring in ASP.NET Identity where the exception was getting wrapped in an AggregateException.
We now walk the tree of inner exceptions looking for a match.
Also adding some extra logging as this was hard to debug without resorting to source code.
