### PR TITLE
Reacting to EF: Setting Identity as ValueGenerationStrategy explicitly

### DIFF
--- a/test/Microsoft.AspNet.Diagnostics.Entity.FunctionalTests/TestModels/BloggingContext.cs
+++ b/test/Microsoft.AspNet.Diagnostics.Entity.FunctionalTests/TestModels/BloggingContext.cs
@@ -28,5 +28,10 @@ namespace Microsoft.AspNet.Diagnostics.Entity.Tests
         { }
 
         public DbSet<Blog> Blogs { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Blog>().Property(e => e.BlogId).ForSqlServer().UseIdentity();
+        }
     }
 }


### PR DESCRIPTION
Setting Identity for value generation for BlogId