### PR TITLE
Using 'nameof' operator instead of magic strings

### DIFF
--- a/src/Microsoft.AspNet.Diagnostics/DiagnosticsPageExtensions.cs
+++ b/src/Microsoft.AspNet.Diagnostics/DiagnosticsPageExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNet.Builder
         {
             if (builder == null)
             {
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             }
 
             return builder.Use(next => new DiagnosticsPageMiddleware(next, options).Invoke);

--- a/src/Microsoft.AspNet.Diagnostics/ErrorPageExtensions.cs
+++ b/src/Microsoft.AspNet.Diagnostics/ErrorPageExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNet.Builder
         {
             if (builder == null)
             {
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             }
 
             return builder.UseErrorPage(new ErrorPageOptions());
@@ -38,7 +38,7 @@ namespace Microsoft.AspNet.Builder
         {
             if (builder == null)
             {
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             }
             /* TODO: Development, Staging, or Production
             string appMode = new AppProperties(builder.Properties).Get<string>(Constants.HostAppMode);

--- a/src/Microsoft.AspNet.Diagnostics/ErrorPageMiddleware.cs
+++ b/src/Microsoft.AspNet.Diagnostics/ErrorPageMiddleware.cs
@@ -35,11 +35,11 @@ namespace Microsoft.AspNet.Diagnostics
         {
             if (next == null)
             {
-                throw new ArgumentNullException("next");
+                throw new ArgumentNullException(nameof(next));
             }
             if (options == null)
             {
-                throw new ArgumentNullException("options");
+                throw new ArgumentNullException(nameof(options));
             }
             if (isDevMode)
             {

--- a/src/Microsoft.AspNet.Diagnostics/WelcomePageExtensions.cs
+++ b/src/Microsoft.AspNet.Diagnostics/WelcomePageExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNet.Builder
         {
             if (builder == null)
             {
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             }
 
             return builder.Use(next => new WelcomePageMiddleware(next, options).Invoke);

--- a/src/Microsoft.AspNet.Diagnostics/WelcomePageMiddleware.cs
+++ b/src/Microsoft.AspNet.Diagnostics/WelcomePageMiddleware.cs
@@ -28,11 +28,11 @@ namespace Microsoft.AspNet.Diagnostics
         {
             if (next == null)
             {
-                throw new ArgumentNullException("next");
+                throw new ArgumentNullException(nameof(next));
             }
             if (options == null)
             {
-                throw new ArgumentNullException("options");
+                throw new ArgumentNullException(nameof(options));
             }
 
             _next = next;


### PR DESCRIPTION
Using the "nameof" operator instead of magic string will help us if the variable change in the future for whatever the reason