### PR TITLE
React to EF Changes: Remove Usage of BasicModelBuilder

### DIFF
--- a/test/Microsoft.AspNet.Diagnostics.Entity.FunctionalTests/TestModels/BloggingContextWithMigrations.cs
+++ b/test/Microsoft.AspNet.Diagnostics.Entity.FunctionalTests/TestModels/BloggingContextWithMigrations.cs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
+using Microsoft.Data.Entity;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
-using Microsoft.Data.Entity.Metadata.Builders;
+using Microsoft.Data.Entity.Metadata.ModelConventions;
 using Microsoft.Data.Entity.Relational.Migrations;
 using Microsoft.Data.Entity.Relational.Migrations.Builders;
 using Microsoft.Data.Entity.Relational.Migrations.Infrastructure;
@@ -35,7 +35,7 @@ namespace Microsoft.AspNet.Diagnostics.Entity.Tests
             {
                 get
                 {
-                    var builder = new BasicModelBuilder();
+                    var builder = new ModelBuilder(new ConventionSet());
 
                     builder.Entity("Blogging.Models.Blog", b =>
                     {

--- a/test/Microsoft.AspNet.Diagnostics.Entity.FunctionalTests/TestModels/BloggingContextWithPendingModelChanges.cs
+++ b/test/Microsoft.AspNet.Diagnostics.Entity.FunctionalTests/TestModels/BloggingContextWithPendingModelChanges.cs
@@ -2,9 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Data.Entity;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
-using Microsoft.Data.Entity.Metadata.Builders;
+using Microsoft.Data.Entity.Metadata.ModelConventions;
 using Microsoft.Data.Entity.Relational.Migrations;
 using Microsoft.Data.Entity.Relational.Migrations.Builders;
 using Microsoft.Data.Entity.Relational.Migrations.Infrastructure;
@@ -22,7 +23,7 @@ namespace Microsoft.AspNet.Diagnostics.Entity.Tests
         {
             public override IModel Model
             {
-                get { return new BasicModelBuilder().Model; }
+                get { return new ModelBuilder(new ConventionSet()).Model; }
             }
         }
 
@@ -41,7 +42,7 @@ namespace Microsoft.AspNet.Diagnostics.Entity.Tests
 
             public override IModel Target
             {
-                get { return new BasicModelBuilder().Model; }
+                get { return new ModelBuilder(new ConventionSet()).Model; }
             }
 
             public override void Up(MigrationBuilder migrationBuilder)


### PR DESCRIPTION
BasicModelBuilder has been removed from EF. EntityFramework@b708d02afc48ad834558dc8be0dad2a0880f98e9
Use ModelBuilder without conventions.