### PR TITLE
Removed SetDefaultVisibility for ErrorPageOptions

### DIFF
--- a/src/Microsoft.AspNet.Diagnostics.Entity/DatabaseErrorPageOptions.cs
+++ b/src/Microsoft.AspNet.Diagnostics.Entity/DatabaseErrorPageOptions.cs
@@ -1,45 +1,18 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNet.Diagnostics.Entity.Utilities;
-using Microsoft.AspNet.Http;
-
 namespace Microsoft.AspNet.Diagnostics.Entity
 {
     public class DatabaseErrorPageOptions
     {
-        private bool _defaultVisibility;
-        private bool? _showExceptionDetails;
-        private bool? _listMigrations;
+        public static DatabaseErrorPageOptions ShowAll => new DatabaseErrorPageOptions
+                                                              {
+                                                                  ShowExceptionDetails = true,
+                                                                  ListMigrations = true,
+                                                              };
 
-        public static DatabaseErrorPageOptions ShowAll
-        {
-            get
-            {
-                // We don't use a static instance because it's mutable.
-                return new DatabaseErrorPageOptions()
-                {
-                    ShowExceptionDetails = true,
-                    ListMigrations = true,
-                };
-            }
-        }
+        public virtual bool ShowExceptionDetails { get; set; }
 
-        public virtual bool ShowExceptionDetails
-        {
-            get { return _showExceptionDetails ?? _defaultVisibility; }
-            set { _showExceptionDetails = value; }
-        }
-
-        public virtual bool ListMigrations
-        {
-            get { return _listMigrations ?? _defaultVisibility; }
-            set { _listMigrations = value; }
-        }
-
-        public virtual void SetDefaultVisibility(bool isVisible)
-        {
-            _defaultVisibility = isVisible;
-        }
+        public virtual bool ListMigrations { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Diagnostics/ErrorPageExtensions.cs
+++ b/src/Microsoft.AspNet.Diagnostics/ErrorPageExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.AspNet.Diagnostics;
 using Microsoft.Framework.Internal;
 
@@ -32,11 +31,7 @@ namespace Microsoft.AspNet.Builder
         /// <returns></returns>
         public static IApplicationBuilder UseErrorPage([NotNull] this IApplicationBuilder builder, ErrorPageOptions options)
         {
-            /* TODO: Development, Staging, or Production
-            string appMode = new AppProperties(builder.Properties).Get<string>(Constants.HostAppMode);
-            bool isDevMode = string.Equals(Constants.DevMode, appMode, StringComparison.Ordinal);*/
-            bool isDevMode = true;
-            return builder.Use(next => new ErrorPageMiddleware(next, options, isDevMode).Invoke);
+            return builder.Use(next => new ErrorPageMiddleware(next, options).Invoke);
         }
     }
 }

--- a/src/Microsoft.AspNet.Diagnostics/ErrorPageMiddleware.cs
+++ b/src/Microsoft.AspNet.Diagnostics/ErrorPageMiddleware.cs
@@ -31,13 +31,8 @@ namespace Microsoft.AspNet.Diagnostics
         /// </summary>
         /// <param name="next"></param>
         /// <param name="options"></param>
-        /// <param name="isDevMode"></param>
-        public ErrorPageMiddleware([NotNull] RequestDelegate next, [NotNull] ErrorPageOptions options, bool isDevMode)
+        public ErrorPageMiddleware([NotNull] RequestDelegate next, [NotNull] ErrorPageOptions options)
         {
-            if (isDevMode)
-            {
-                options.SetDefaultVisibility(isVisible: true);
-            }
             _next = next;
             _options = options;
         }

--- a/src/Microsoft.AspNet.Diagnostics/ErrorPageOptions.cs
+++ b/src/Microsoft.AspNet.Diagnostics/ErrorPageOptions.cs
@@ -5,19 +5,10 @@
 namespace Microsoft.AspNet.Diagnostics
 {
     /// <summary>
-    /// Options for the ErrorPageMiddleware
+    /// Options for the ErrorPageMiddleware.
     /// </summary>
     public class ErrorPageOptions
     {
-        private bool _defaultVisibility;
-
-        private bool? _showExceptionDetails;
-        private bool? _showSourceCode;
-        private bool? _showQuery;
-        private bool? _showCookies;
-        private bool? _showHeaders;
-        private bool? _showEnvironment;
-
         /// <summary>
         /// Create an instance with the default options settings.
         /// </summary>
@@ -29,40 +20,25 @@ namespace Microsoft.AspNet.Diagnostics
         /// <summary>
         /// Returns a new instance of ErrorPageOptions with all visibility options enabled by default.
         /// </summary>
-        public static ErrorPageOptions ShowAll
-        {
-            get
-            {
-                // We don't use a static instance because it's mutable.
-                return new ErrorPageOptions()
-                {
-                    ShowExceptionDetails = true,
-                    ShowSourceCode = true,
-                    ShowQuery = true,
-                    ShowCookies = true,
-                    ShowHeaders = true,
-                    ShowEnvironment = true,
-                };
-            }
-        }
+        public static ErrorPageOptions ShowAll => new ErrorPageOptions
+                                                      {
+                                                          ShowExceptionDetails = true,
+                                                          ShowSourceCode = true,
+                                                          ShowQuery = true,
+                                                          ShowCookies = true,
+                                                          ShowHeaders = true,
+                                                          ShowEnvironment = true,
+                                                      };
 
         /// <summary>
         /// Enables the display of exception types, messages, and stack traces.
         /// </summary>
-        public bool ShowExceptionDetails
-        {
-            get { return _showExceptionDetails ?? _defaultVisibility; }
-            set { _showExceptionDetails = value; }
-        }
+        public bool ShowExceptionDetails { get; set; }
 
         /// <summary>
         /// Enabled the display of local source code around exception stack frames.
         /// </summary>
-        public bool ShowSourceCode
-        {
-            get { return _showSourceCode ?? _defaultVisibility; }
-            set { _showSourceCode = value; }
-        }
+        public bool ShowSourceCode { get; set; }
 
         /// <summary>
         /// Determines how many lines of code to include before and after the line of code
@@ -74,46 +50,21 @@ namespace Microsoft.AspNet.Diagnostics
         /// <summary>
         /// Enables the enumeration of any parsed query values.
         /// </summary>
-        public bool ShowQuery
-        {
-            get { return _showQuery ?? _defaultVisibility; }
-            set { _showQuery = value; }
-        }
+        public bool ShowQuery { get; set; }
 
         /// <summary>
         /// Enables the enumeration of any parsed request cookies.
         /// </summary>
-        public bool ShowCookies
-        {
-            get { return _showCookies ?? _defaultVisibility; }
-            set { _showCookies = value; }
-        }
+        public bool ShowCookies { get; set; }
 
         /// <summary>
         /// Enables the enumeration of the request headers.
         /// </summary>
-        public bool ShowHeaders
-        {
-            get { return _showHeaders ?? _defaultVisibility; }
-            set { _showHeaders = value; }
-        }
+        public bool ShowHeaders { get; set; }
 
         /// <summary>
         /// Enables the enumeration of the OWIN environment values.
         /// </summary>
-        public bool ShowEnvironment
-        {
-            get { return _showEnvironment ?? _defaultVisibility; }
-            set { _showEnvironment = value; }
-        }
-
-        /// <summary>
-        /// Sets the default visibility for options not otherwise specified.
-        /// </summary>
-        /// <param name="isVisible"></param>
-        public void SetDefaultVisibility(bool isVisible)
-        {
-            _defaultVisibility = isVisible;
-        }
+        public bool ShowEnvironment { get; set; }
     }
 }

--- a/test/Microsoft.AspNet.Diagnostics.Entity.Tests/DatabaseErrorPageOptionsTest.cs
+++ b/test/Microsoft.AspNet.Diagnostics.Entity.Tests/DatabaseErrorPageOptionsTest.cs
@@ -17,32 +17,29 @@ namespace Microsoft.AspNet.Diagnostics.Entity.Tests
         }
 
         [Fact]
-        public void Default_visibility_can_be_changed()
+        public void ShowAll_shows_all_errors()
         {
-            var options = new DatabaseErrorPageOptions();
-            options.SetDefaultVisibility(true);
+            var options = DatabaseErrorPageOptions.ShowAll;
 
             Assert.True(options.ShowExceptionDetails);
             Assert.True(options.ListMigrations);
         }
 
         [Fact]
-        public void ShowExceptionDetails_overides_default_visibility()
+        public void ShowExceptionDetails_is_respected()
         {
-            var options = new DatabaseErrorPageOptions { ShowExceptionDetails = false };
-            options.SetDefaultVisibility(true);
+            var options = DatabaseErrorPageOptions.ShowAll;
+            options.ShowExceptionDetails = false;
 
             Assert.False(options.ShowExceptionDetails);
-            Assert.True(options.ListMigrations);
         }
 
         [Fact]
-        public void ListMigrations_overides_default_visibility()
+        public void ListMigrations_is_respected()
         {
-            var options = new DatabaseErrorPageOptions { ListMigrations = false };
-            options.SetDefaultVisibility(true);
+            var options = DatabaseErrorPageOptions.ShowAll;
+            options.ListMigrations = false;
 
-            Assert.True(options.ShowExceptionDetails);
             Assert.False(options.ListMigrations);
         }
     }

--- a/test/Microsoft.AspNet.Diagnostics.Entity.Tests/DatabaseErrorPageTest.cs
+++ b/test/Microsoft.AspNet.Diagnostics.Entity.Tests/DatabaseErrorPageTest.cs
@@ -19,8 +19,7 @@ namespace Microsoft.AspNet.Diagnostics.Entity.Tests
         [Fact]
         public async Task No_database_or_migrations_only_displays_scaffold_first_migration()
         {
-            var options = new DatabaseErrorPageOptions();
-            options.SetDefaultVisibility(true);
+            var options = DatabaseErrorPageOptions.ShowAll;
 
             var model = new DatabaseErrorPageModel(
                 contextType: typeof(BloggingContext),
@@ -40,8 +39,7 @@ namespace Microsoft.AspNet.Diagnostics.Entity.Tests
         [Fact]
         public async Task No_database_with_migrations_only_displays_apply_migrations()
         {
-            var options = new DatabaseErrorPageOptions();
-            options.SetDefaultVisibility(true);
+            var options = DatabaseErrorPageOptions.ShowAll;
 
             var model = new DatabaseErrorPageModel(
                 contextType: typeof(BloggingContext),
@@ -61,8 +59,7 @@ namespace Microsoft.AspNet.Diagnostics.Entity.Tests
         [Fact]
         public async Task Existing_database_with_migrations_only_displays_apply_migrations()
         {
-            var options = new DatabaseErrorPageOptions();
-            options.SetDefaultVisibility(true);
+            var options = DatabaseErrorPageOptions.ShowAll;
 
             var model = new DatabaseErrorPageModel(
                 contextType: typeof(BloggingContext),
@@ -82,8 +79,7 @@ namespace Microsoft.AspNet.Diagnostics.Entity.Tests
         [Fact]
         public async Task Existing_database_with_migrations_and_pending_model_changes_only_displays_apply_migrations()
         {
-            var options = new DatabaseErrorPageOptions();
-            options.SetDefaultVisibility(true);
+            var options = DatabaseErrorPageOptions.ShowAll;
 
             var model = new DatabaseErrorPageModel(
                 contextType: typeof(BloggingContext),
@@ -103,8 +99,7 @@ namespace Microsoft.AspNet.Diagnostics.Entity.Tests
         [Fact]
         public async Task Pending_model_changes_only_displays_scaffold_next_migration()
         {
-            var options = new DatabaseErrorPageOptions();
-            options.SetDefaultVisibility(true);
+            var options = DatabaseErrorPageOptions.ShowAll;
 
             var model = new DatabaseErrorPageModel(
                 contextType: typeof(BloggingContext),
@@ -124,8 +119,7 @@ namespace Microsoft.AspNet.Diagnostics.Entity.Tests
         [Fact]
         public async Task Exception_details_are_displayed()
         {
-            var options = new DatabaseErrorPageOptions();
-            options.SetDefaultVisibility(true);
+            var options = DatabaseErrorPageOptions.ShowAll;
 
             var model = new DatabaseErrorPageModel(
                 contextType: typeof(BloggingContext),
@@ -143,8 +137,7 @@ namespace Microsoft.AspNet.Diagnostics.Entity.Tests
         [Fact]
         public async Task Inner_exception_details_are_displayed()
         {
-            var options = new DatabaseErrorPageOptions();
-            options.SetDefaultVisibility(true);
+            var options = DatabaseErrorPageOptions.ShowAll;
 
             var model = new DatabaseErrorPageModel(
                 contextType: typeof(BloggingContext),
@@ -163,8 +156,8 @@ namespace Microsoft.AspNet.Diagnostics.Entity.Tests
         [Fact]
         public async Task ShowExceptionDetails_is_respected()
         {
-            var options = new DatabaseErrorPageOptions { ShowExceptionDetails = false };
-            options.SetDefaultVisibility(true);
+            var options = DatabaseErrorPageOptions.ShowAll;
+            options.ShowExceptionDetails = false;
 
             var model = new DatabaseErrorPageModel(
                 contextType: typeof(BloggingContext),
@@ -182,8 +175,8 @@ namespace Microsoft.AspNet.Diagnostics.Entity.Tests
         [Fact]
         public async Task ListMigrations_is_respected()
         {
-            var options = new DatabaseErrorPageOptions { ListMigrations = false };
-            options.SetDefaultVisibility(true);
+            var options = DatabaseErrorPageOptions.ShowAll;
+            options.ListMigrations = false;
 
             var model = new DatabaseErrorPageModel(
                contextType: typeof(BloggingContext),


### PR DESCRIPTION
- Removed `SetDefaultVisibility` method from `(Database)ErrorPageOptions`
- `(Database)ErrorPageOptions` properties are now auto-properties since there is no default visibility anymore
- Removed `isDevMode` parameter from `ErrorPageMiddleware` ctor
- Removed comments from `ErroPageExtensions.UseErrorPage()`
- Updated Entity tests

#130