### PR TITLE
Remove ErrorPageOptions properties except SourceCodeLineCount

### DIFF
--- a/DiagnosticsPages.sln
+++ b/DiagnosticsPages.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22530.0
+VisualStudioVersion = 14.0.22823.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{509A6F36-AD80-4A18-B5B1-717D38DFF29D}"
 EndProject

--- a/samples/StatusCodePagesSample/Startup.cs
+++ b/samples/StatusCodePagesSample/Startup.cs
@@ -16,7 +16,7 @@ namespace StatusCodePagesSample
     {
         public void Configure(IApplicationBuilder app)
         {
-            app.UseErrorPage(ErrorPageOptions.ShowAll);
+            app.UseErrorPage();
             app.UseStatusCodePages(); // There is a default response but any of the following can be used to change the behavior.
 
             // app.UseStatusCodePages(context => context.HttpContext.Response.SendAsync("Handler, status code: " + context.HttpContext.Response.StatusCode, "text/plain"));

--- a/src/Microsoft.AspNet.Diagnostics/ErrorPageOptions.cs
+++ b/src/Microsoft.AspNet.Diagnostics/ErrorPageOptions.cs
@@ -18,53 +18,10 @@ namespace Microsoft.AspNet.Diagnostics
         }
 
         /// <summary>
-        /// Returns a new instance of ErrorPageOptions with all visibility options enabled by default.
-        /// </summary>
-        public static ErrorPageOptions ShowAll => new ErrorPageOptions
-                                                      {
-                                                          ShowExceptionDetails = true,
-                                                          ShowSourceCode = true,
-                                                          ShowQuery = true,
-                                                          ShowCookies = true,
-                                                          ShowHeaders = true,
-                                                          ShowEnvironment = true,
-                                                      };
-
-        /// <summary>
-        /// Enables the display of exception types, messages, and stack traces.
-        /// </summary>
-        public bool ShowExceptionDetails { get; set; }
-
-        /// <summary>
-        /// Enabled the display of local source code around exception stack frames.
-        /// </summary>
-        public bool ShowSourceCode { get; set; }
-
-        /// <summary>
         /// Determines how many lines of code to include before and after the line of code
-        /// present in an exception's stack frame. Only applies when symbols are available and 
+        /// present in an exception's stack frame. Only applies when symbols are available and
         /// source code referenced by the exception stack trace is present on the server.
         /// </summary>
         public int SourceCodeLineCount { get; set; }
-
-        /// <summary>
-        /// Enables the enumeration of any parsed query values.
-        /// </summary>
-        public bool ShowQuery { get; set; }
-
-        /// <summary>
-        /// Enables the enumeration of any parsed request cookies.
-        /// </summary>
-        public bool ShowCookies { get; set; }
-
-        /// <summary>
-        /// Enables the enumeration of the request headers.
-        /// </summary>
-        public bool ShowHeaders { get; set; }
-
-        /// <summary>
-        /// Enables the enumeration of the OWIN environment values.
-        /// </summary>
-        public bool ShowEnvironment { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Diagnostics/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Diagnostics/Properties/Resources.Designer.cs
@@ -91,22 +91,6 @@ namespace Microsoft.AspNet.Diagnostics
         }
 
         /// <summary>
-        /// Enable development mode or ErrorPageOptions.ShowExceptionDetails for additional information.
-        /// </summary>
-        internal static string ErrorPageHtml_EnableShowExceptions
-        {
-            get { return GetString("ErrorPageHtml_EnableShowExceptions"); }
-        }
-
-        /// <summary>
-        /// Enable development mode or ErrorPageOptions.ShowExceptionDetails for additional information.
-        /// </summary>
-        internal static string FormatErrorPageHtml_EnableShowExceptions()
-        {
-            return GetString("ErrorPageHtml_EnableShowExceptions");
-        }
-
-        /// <summary>
         /// Environment
         /// </summary>
         internal static string ErrorPageHtml_EnvironmentButton

--- a/src/Microsoft.AspNet.Diagnostics/Resources.resx
+++ b/src/Microsoft.AspNet.Diagnostics/Resources.resx
@@ -133,9 +133,6 @@
     <value>Cookies</value>
     <comment>as in http request cookies</comment>
   </data>
-  <data name="ErrorPageHtml_EnableShowExceptions" xml:space="preserve">
-    <value>Enable development mode or ErrorPageOptions.ShowExceptionDetails for additional information.</value>
-  </data>
   <data name="ErrorPageHtml_EnvironmentButton" xml:space="preserve">
     <value>Environment</value>
     <comment>as in environment dictionary</comment>

--- a/src/Microsoft.AspNet.Diagnostics/Views/CompilationErrorPage.cs
+++ b/src/Microsoft.AspNet.Diagnostics/Views/CompilationErrorPage.cs
@@ -79,298 +79,274 @@ using Views
 #line hidden
 
 #line 26 "CompilationErrorPage.cshtml"
-         if (!Model.Options.ShowExceptionDetails)
+         foreach (var errorDetail in Model.ErrorDetails)
         {
 
 #line default
 #line hidden
 
-            WriteLiteral("            <h2>");
-#line 28 "CompilationErrorPage.cshtml"
-           Write(Resources.ErrorPageHtml_EnableShowExceptions);
-
-#line default
-#line hidden
-            WriteLiteral("</h2>\r\n");
+            WriteLiteral("            <div id=\"stackpage\" class=\"page\">\r\n");
 #line 29 "CompilationErrorPage.cshtml"
-        }
+                
 
 #line default
 #line hidden
 
-            WriteLiteral("        ");
-#line 30 "CompilationErrorPage.cshtml"
-         if (Model.Options.ShowExceptionDetails)
-        {
-            foreach (var errorDetail in Model.ErrorDetails)
-            {
-
-#line default
-#line hidden
-
-            WriteLiteral("                <div id=\"stackpage\" class=\"page\">\r\n");
-#line 35 "CompilationErrorPage.cshtml"
-                    
-
-#line default
-#line hidden
-
-#line 35 "CompilationErrorPage.cshtml"
-                       int tabIndex = 6; 
+#line 29 "CompilationErrorPage.cshtml"
+                   int tabIndex = 6; 
 
 #line default
 #line hidden
 
             WriteLiteral("\r\n");
-#line 36 "CompilationErrorPage.cshtml"
-                    
+#line 30 "CompilationErrorPage.cshtml"
+                
 
 #line default
 #line hidden
 
-#line 36 "CompilationErrorPage.cshtml"
-                      
-                        var fileName = errorDetail.StackFrames.FirstOrDefault()?.File;
-                        if (!string.IsNullOrEmpty(fileName))
-                        {
-
-#line default
-#line hidden
-
-            WriteLiteral("                            <div class=\"titleerror\">");
-#line 40 "CompilationErrorPage.cshtml"
-                                               Write(fileName);
-
-#line default
-#line hidden
-            WriteLiteral("</div>\r\n");
-#line 41 "CompilationErrorPage.cshtml"
-                        }
-                    
-
-#line default
-#line hidden
-
-            WriteLiteral("\r\n                    <br />\r\n                    <ul>\r\n");
-#line 45 "CompilationErrorPage.cshtml"
-                    
-
-#line default
-#line hidden
-
-#line 45 "CompilationErrorPage.cshtml"
-                     foreach (var frame in errorDetail.StackFrames)
+#line 30 "CompilationErrorPage.cshtml"
+                  
+                    var fileName = errorDetail.StackFrames.FirstOrDefault()?.File;
+                    if (!string.IsNullOrEmpty(fileName))
                     {
 
 #line default
 #line hidden
 
-            WriteLiteral("                        <li class=\"frame\"");
-            WriteAttribute("tabindex", Tuple.Create(" tabindex=\"", 1496), Tuple.Create("\"", 1516), 
-            Tuple.Create(Tuple.Create("", 1507), Tuple.Create<System.Object, System.Int32>(tabIndex, 1507), false));
-            WriteLiteral(">\r\n");
-#line 48 "CompilationErrorPage.cshtml"
-                            
+            WriteLiteral("                        <div class=\"titleerror\">");
+#line 34 "CompilationErrorPage.cshtml"
+                                           Write(fileName);
+
+#line default
+#line hidden
+            WriteLiteral("</div>\r\n");
+#line 35 "CompilationErrorPage.cshtml"
+                    }
+                
 
 #line default
 #line hidden
 
-#line 48 "CompilationErrorPage.cshtml"
-                               tabIndex++; 
+            WriteLiteral("\r\n                <br />\r\n                <ul>\r\n");
+#line 39 "CompilationErrorPage.cshtml"
+                
+
+#line default
+#line hidden
+
+#line 39 "CompilationErrorPage.cshtml"
+                 foreach (var frame in errorDetail.StackFrames)
+                {
+
+#line default
+#line hidden
+
+            WriteLiteral("                    <li class=\"frame\"");
+            WriteAttribute("tabindex", Tuple.Create(" tabindex=\"", 1231), Tuple.Create("\"", 1251), 
+            Tuple.Create(Tuple.Create("", 1242), Tuple.Create<System.Object, System.Int32>(tabIndex, 1242), false));
+            WriteLiteral(">\r\n");
+#line 42 "CompilationErrorPage.cshtml"
+                        
+
+#line default
+#line hidden
+
+#line 42 "CompilationErrorPage.cshtml"
+                           tabIndex++; 
 
 #line default
 #line hidden
 
             WriteLiteral("\r\n");
-#line 49 "CompilationErrorPage.cshtml"
-                            
+#line 43 "CompilationErrorPage.cshtml"
+                        
 
 #line default
 #line hidden
 
-#line 49 "CompilationErrorPage.cshtml"
-                             if (!string.IsNullOrEmpty(frame.ErrorDetails))
-                            {
+#line 43 "CompilationErrorPage.cshtml"
+                         if (!string.IsNullOrEmpty(frame.ErrorDetails))
+                        {
 
 #line default
 #line hidden
 
-            WriteLiteral("                                <h3>");
-#line 51 "CompilationErrorPage.cshtml"
-                               Write(frame.ErrorDetails);
+            WriteLiteral("                            <h3>");
+#line 45 "CompilationErrorPage.cshtml"
+                           Write(frame.ErrorDetails);
 
 #line default
 #line hidden
             WriteLiteral("</h3>\r\n");
-#line 52 "CompilationErrorPage.cshtml"
-                            }
+#line 46 "CompilationErrorPage.cshtml"
+                        }
 
 #line default
 #line hidden
 
             WriteLiteral("\r\n");
-#line 54 "CompilationErrorPage.cshtml"
-                            
+#line 48 "CompilationErrorPage.cshtml"
+                        
 
 #line default
 #line hidden
 
-#line 54 "CompilationErrorPage.cshtml"
-                             if (frame.Line != 0 && frame.ContextCode.Any())
-                            {
+#line 48 "CompilationErrorPage.cshtml"
+                         if (frame.Line != 0 && frame.ContextCode.Any())
+                        {
 
 #line default
 #line hidden
 
-            WriteLiteral("                                <div class=\"source\">\r\n");
-#line 57 "CompilationErrorPage.cshtml"
-                                    
+            WriteLiteral("                            <div class=\"source\">\r\n");
+#line 51 "CompilationErrorPage.cshtml"
+                                
 
 #line default
 #line hidden
 
-#line 57 "CompilationErrorPage.cshtml"
-                                     if (frame.PreContextCode != null)
-                                    {
-
-#line default
-#line hidden
-
-            WriteLiteral("                                        <ol");
-            WriteAttribute("start", Tuple.Create(" start=\"", 2086), Tuple.Create("\"", 2115), 
-            Tuple.Create(Tuple.Create("", 2094), Tuple.Create<System.Object, System.Int32>(frame.PreContextLine, 2094), false));
-            WriteLiteral(" class=\"collapsible\">\r\n");
-#line 60 "CompilationErrorPage.cshtml"
-                                            
-
-#line default
-#line hidden
-
-#line 60 "CompilationErrorPage.cshtml"
-                                             foreach (var line in frame.PreContextCode)
-                                            {
-
-#line default
-#line hidden
-
-            WriteLiteral("                                                <li><span>");
-#line 62 "CompilationErrorPage.cshtml"
-                                                     Write(line);
-
-#line default
-#line hidden
-            WriteLiteral("</span></li>\r\n");
-#line 63 "CompilationErrorPage.cshtml"
-                                            }
-
-#line default
-#line hidden
-
-            WriteLiteral("                                        </ol>\r\n");
-#line 65 "CompilationErrorPage.cshtml"
-                                    }
+#line 51 "CompilationErrorPage.cshtml"
+                                 if (frame.PreContextCode != null)
+                                {
 
 #line default
 #line hidden
 
             WriteLiteral("                                    <ol");
-            WriteAttribute("start", Tuple.Create(" start=\"", 2524), Tuple.Create("\"", 2543), 
-            Tuple.Create(Tuple.Create("", 2532), Tuple.Create<System.Object, System.Int32>(frame.Line, 2532), false));
-            WriteLiteral(" class=\"highlight\">\r\n");
-#line 67 "CompilationErrorPage.cshtml"
+            WriteAttribute("start", Tuple.Create(" start=\"", 1777), Tuple.Create("\"", 1806), 
+            Tuple.Create(Tuple.Create("", 1785), Tuple.Create<System.Object, System.Int32>(frame.PreContextLine, 1785), false));
+            WriteLiteral(" class=\"collapsible\">\r\n");
+#line 54 "CompilationErrorPage.cshtml"
                                         
 
 #line default
 #line hidden
 
-#line 67 "CompilationErrorPage.cshtml"
-                                         foreach (var line in frame.ContextCode)
+#line 54 "CompilationErrorPage.cshtml"
+                                         foreach (var line in frame.PreContextCode)
                                         {
 
 #line default
 #line hidden
 
             WriteLiteral("                                            <li><span>");
-#line 69 "CompilationErrorPage.cshtml"
+#line 56 "CompilationErrorPage.cshtml"
                                                  Write(line);
 
 #line default
 #line hidden
             WriteLiteral("</span></li>\r\n");
-#line 70 "CompilationErrorPage.cshtml"
+#line 57 "CompilationErrorPage.cshtml"
                                         }
 
 #line default
 #line hidden
 
             WriteLiteral("                                    </ol>\r\n");
-#line 72 "CompilationErrorPage.cshtml"
+#line 59 "CompilationErrorPage.cshtml"
+                                }
+
+#line default
+#line hidden
+
+            WriteLiteral("                                <ol");
+            WriteAttribute("start", Tuple.Create(" start=\"", 2187), Tuple.Create("\"", 2206), 
+            Tuple.Create(Tuple.Create("", 2195), Tuple.Create<System.Object, System.Int32>(frame.Line, 2195), false));
+            WriteLiteral(" class=\"highlight\">\r\n");
+#line 61 "CompilationErrorPage.cshtml"
                                     
 
 #line default
 #line hidden
 
-#line 72 "CompilationErrorPage.cshtml"
-                                     if (frame.PostContextCode != null)
+#line 61 "CompilationErrorPage.cshtml"
+                                     foreach (var line in frame.ContextCode)
                                     {
 
 #line default
 #line hidden
 
-            WriteLiteral("                                        <ol");
-            WriteAttribute("start", Tuple.Create(" start=\'", 3004), Tuple.Create("\'", 3029), 
-            Tuple.Create(Tuple.Create("", 3012), Tuple.Create<System.Object, System.Int32>(frame.Line + 1, 3012), false));
-            WriteLiteral(" class=\"collapsible\">\r\n");
-#line 75 "CompilationErrorPage.cshtml"
-                                            
-
-#line default
-#line hidden
-
-#line 75 "CompilationErrorPage.cshtml"
-                                             foreach (var line in frame.PostContextCode)
-                                            {
-
-#line default
-#line hidden
-
-            WriteLiteral("                                                <li><span>");
-#line 77 "CompilationErrorPage.cshtml"
-                                                     Write(line);
+            WriteLiteral("                                        <li><span>");
+#line 63 "CompilationErrorPage.cshtml"
+                                             Write(line);
 
 #line default
 #line hidden
             WriteLiteral("</span></li>\r\n");
+#line 64 "CompilationErrorPage.cshtml"
+                                    }
+
+#line default
+#line hidden
+
+            WriteLiteral("                                </ol>\r\n");
+#line 66 "CompilationErrorPage.cshtml"
+                                
+
+#line default
+#line hidden
+
+#line 66 "CompilationErrorPage.cshtml"
+                                 if (frame.PostContextCode != null)
+                                {
+
+#line default
+#line hidden
+
+            WriteLiteral("                                    <ol");
+            WriteAttribute("start", Tuple.Create(" start=\'", 2635), Tuple.Create("\'", 2660), 
+            Tuple.Create(Tuple.Create("", 2643), Tuple.Create<System.Object, System.Int32>(frame.Line + 1, 2643), false));
+            WriteLiteral(" class=\"collapsible\">\r\n");
+#line 69 "CompilationErrorPage.cshtml"
+                                        
+
+#line default
+#line hidden
+
+#line 69 "CompilationErrorPage.cshtml"
+                                         foreach (var line in frame.PostContextCode)
+                                        {
+
+#line default
+#line hidden
+
+            WriteLiteral("                                            <li><span>");
+#line 71 "CompilationErrorPage.cshtml"
+                                                 Write(line);
+
+#line default
+#line hidden
+            WriteLiteral("</span></li>\r\n");
+#line 72 "CompilationErrorPage.cshtml"
+                                        }
+
+#line default
+#line hidden
+
+            WriteLiteral("                                    </ol>\r\n");
+#line 74 "CompilationErrorPage.cshtml"
+                                } 
+
+#line default
+#line hidden
+
+            WriteLiteral("                            </div>\r\n");
+#line 76 "CompilationErrorPage.cshtml"
+                        } 
+
+#line default
+#line hidden
+
+            WriteLiteral("                    </li>\r\n");
 #line 78 "CompilationErrorPage.cshtml"
-                                            }
+                }
 
 #line default
 #line hidden
 
-            WriteLiteral("                                        </ol>\r\n");
-#line 80 "CompilationErrorPage.cshtml"
-                                    } 
-
-#line default
-#line hidden
-
-            WriteLiteral("                                </div>\r\n");
+            WriteLiteral("                </ul>\r\n                <br />\r\n            </div>\r\n");
 #line 82 "CompilationErrorPage.cshtml"
-                            } 
-
-#line default
-#line hidden
-
-            WriteLiteral("                        </li>\r\n");
-#line 84 "CompilationErrorPage.cshtml"
-                    }
-
-#line default
-#line hidden
-
-            WriteLiteral("                    </ul>\r\n                    <br />\r\n                </div>\r\n");
-#line 88 "CompilationErrorPage.cshtml"
-            }
         }
 
 #line default

--- a/src/Microsoft.AspNet.Diagnostics/Views/CompilationErrorPage.cshtml
+++ b/src/Microsoft.AspNet.Diagnostics/Views/CompilationErrorPage.cshtml
@@ -23,69 +23,62 @@
     </head>
     <body>
         <h1>@Resources.ErrorPageHtml_CompilationException</h1>
-        @if (!Model.Options.ShowExceptionDetails)
+        @foreach (var errorDetail in Model.ErrorDetails)
         {
-            <h2>@Resources.ErrorPageHtml_EnableShowExceptions</h2>
-        }
-        @if (Model.Options.ShowExceptionDetails)
-        {
-            foreach (var errorDetail in Model.ErrorDetails)
-            {
-                <div id="stackpage" class="page">
-                    @{ int tabIndex = 6; }
-                    @{
-                        var fileName = errorDetail.StackFrames.FirstOrDefault()?.File;
-                        if (!string.IsNullOrEmpty(fileName))
-                        {
-                            <div class="titleerror">@fileName</div>
-                        }
-                    }
-                    <br />
-                    <ul>
-                    @foreach (var frame in errorDetail.StackFrames)
+            <div id="stackpage" class="page">
+                @{ int tabIndex = 6; }
+                @{
+                    var fileName = errorDetail.StackFrames.FirstOrDefault()?.File;
+                    if (!string.IsNullOrEmpty(fileName))
                     {
-                        <li class="frame" tabindex="@tabIndex">
-                            @{ tabIndex++; }
-                            @if (!string.IsNullOrEmpty(frame.ErrorDetails))
-                            {
-                                <h3>@frame.ErrorDetails</h3>
-                            }
+                        <div class="titleerror">@fileName</div>
+                    }
+                }
+                <br />
+                <ul>
+                @foreach (var frame in errorDetail.StackFrames)
+                {
+                    <li class="frame" tabindex="@tabIndex">
+                        @{ tabIndex++; }
+                        @if (!string.IsNullOrEmpty(frame.ErrorDetails))
+                        {
+                            <h3>@frame.ErrorDetails</h3>
+                        }
 
-                            @if (frame.Line != 0 && frame.ContextCode.Any())
-                            {
-                                <div class="source">
-                                    @if (frame.PreContextCode != null)
-                                    {
-                                        <ol start="@frame.PreContextLine" class="collapsible">
-                                            @foreach (var line in frame.PreContextCode)
-                                            {
-                                                <li><span>@line</span></li>
-                                            }
-                                        </ol>
-                                    }
-                                    <ol start="@frame.Line" class="highlight">
-                                        @foreach (var line in frame.ContextCode)
+                        @if (frame.Line != 0 && frame.ContextCode.Any())
+                        {
+                            <div class="source">
+                                @if (frame.PreContextCode != null)
+                                {
+                                    <ol start="@frame.PreContextLine" class="collapsible">
+                                        @foreach (var line in frame.PreContextCode)
                                         {
                                             <li><span>@line</span></li>
                                         }
                                     </ol>
-                                    @if (frame.PostContextCode != null)
+                                }
+                                <ol start="@frame.Line" class="highlight">
+                                    @foreach (var line in frame.ContextCode)
                                     {
-                                        <ol start='@(frame.Line + 1)' class="collapsible">
-                                            @foreach (var line in frame.PostContextCode)
-                                            {
-                                                <li><span>@line</span></li>
-                                            }
-                                        </ol>
-                                    } 
-                                </div>
-                            } 
-                        </li>
-                    }
-                    </ul>
-                    <br />
-                </div>
-            }
+                                        <li><span>@line</span></li>
+                                    }
+                                </ol>
+                                @if (frame.PostContextCode != null)
+                                {
+                                    <ol start='@(frame.Line + 1)' class="collapsible">
+                                        @foreach (var line in frame.PostContextCode)
+                                        {
+                                            <li><span>@line</span></li>
+                                        }
+                                    </ol>
+                                } 
+                            </div>
+                        } 
+                    </li>
+                }
+                </ul>
+                <br />
+            </div>
         }
         <script>
             //<!--

--- a/src/Microsoft.AspNet.Diagnostics/Views/ErrorPage.cs
+++ b/src/Microsoft.AspNet.Diagnostics/Views/ErrorPage.cs
@@ -89,800 +89,703 @@ using Views
 #line hidden
 
 #line 33 "ErrorPage.cshtml"
-         if (Model.Options.ShowExceptionDetails)
+         foreach (var errorDetail in Model.ErrorDetails)
         {
-            foreach (var errorDetail in Model.ErrorDetails)
-            {
 
 #line default
 #line hidden
 
-            WriteLiteral("                <div class=\"titleerror\">");
-#line 37 "ErrorPage.cshtml"
-                                   Write(errorDetail.Error.GetType().Name);
+            WriteLiteral("            <div class=\"titleerror\">");
+#line 35 "ErrorPage.cshtml"
+                               Write(errorDetail.Error.GetType().Name);
 
 #line default
 #line hidden
             WriteLiteral(": ");
-#line 37 "ErrorPage.cshtml"
-                                                                              Output.Write(HtmlEncodeAndReplaceLineBreaks(errorDetail.Error.Message)); 
+#line 35 "ErrorPage.cshtml"
+                                                                          Output.Write(HtmlEncodeAndReplaceLineBreaks(errorDetail.Error.Message)); 
 
 #line default
 #line hidden
 
             WriteLiteral("</div>\r\n");
-#line 38 "ErrorPage.cshtml"
-                
-
-#line default
-#line hidden
-
-#line 38 "ErrorPage.cshtml"
-                  
-                    StackFrame firstFrame = null;
-                    firstFrame = errorDetail.StackFrames.FirstOrDefault();
-                    if (firstFrame != null)
-                    {
-                        location = firstFrame.Function;
-                    }/* TODO: TargetSite is not defined
-                    else if (errorDetail.Error.TargetSite != null && errorDetail.Error.TargetSite.DeclaringType != null)
-                    {
-                        location = errorDetail.Error.TargetSite.DeclaringType.FullName + "." + errorDetail.Error.TargetSite.Name;
-                    }*/
-                
-
-#line default
-#line hidden
-
-#line 49 "ErrorPage.cshtml"
-                 
-                if (!string.IsNullOrEmpty(location) && firstFrame != null && !string.IsNullOrEmpty(firstFrame.File))
-                {
-
-#line default
-#line hidden
-
-            WriteLiteral("                    <p class=\"location\">");
-#line 52 "ErrorPage.cshtml"
-                                   Write(location);
-
-#line default
-#line hidden
-            WriteLiteral(" in <code");
-            WriteAttribute("title", Tuple.Create(" title=\"", 2027), Tuple.Create("\"", 2051), 
-            Tuple.Create(Tuple.Create("", 2035), Tuple.Create<System.Object, System.Int32>(firstFrame.File, 2035), false));
-            WriteLiteral(">");
-#line 52 "ErrorPage.cshtml"
-                                                                               Write(System.IO.Path.GetFileName(firstFrame.File));
-
-#line default
-#line hidden
-            WriteLiteral("</code>, line ");
-#line 52 "ErrorPage.cshtml"
-                                                                                                                                         Write(firstFrame.Line);
-
-#line default
-#line hidden
-            WriteLiteral("</p>\r\n");
-#line 53 "ErrorPage.cshtml"
-                }
-                else if (!string.IsNullOrEmpty(location))
-                {
-
-#line default
-#line hidden
-
-            WriteLiteral("                    <p class=\"location\">");
-#line 56 "ErrorPage.cshtml"
-                                   Write(location);
-
-#line default
-#line hidden
-            WriteLiteral("</p>\r\n");
-#line 57 "ErrorPage.cshtml"
-                }
-                else
-                {
-
-#line default
-#line hidden
-
-            WriteLiteral("                    <p class=\"location\">");
-#line 60 "ErrorPage.cshtml"
-                                   Write(Resources.ErrorPageHtml_UnknownLocation);
-
-#line default
-#line hidden
-            WriteLiteral("</p>\r\n");
-#line 61 "ErrorPage.cshtml"
-                }
-            }
-        }
-        else
-        {
-
-#line default
-#line hidden
-
-            WriteLiteral("            <h2>");
-#line 66 "ErrorPage.cshtml"
-           Write(Resources.ErrorPageHtml_EnableShowExceptions);
-
-#line default
-#line hidden
-            WriteLiteral("</h2>\r\n");
-#line 67 "ErrorPage.cshtml"
-        }
-
-#line default
-#line hidden
-
-            WriteLiteral("        <ul id=\"header\">\r\n");
-#line 69 "ErrorPage.cshtml"
+#line 36 "ErrorPage.cshtml"
             
 
 #line default
 #line hidden
 
-#line 69 "ErrorPage.cshtml"
-             if (Model.Options.ShowExceptionDetails)
+#line 36 "ErrorPage.cshtml"
+              
+                StackFrame firstFrame = null;
+                firstFrame = errorDetail.StackFrames.FirstOrDefault();
+                if (firstFrame != null)
+                {
+                    location = firstFrame.Function;
+                }/* TODO: TargetSite is not defined
+                else if (errorDetail.Error.TargetSite != null && errorDetail.Error.TargetSite.DeclaringType != null)
+                {
+                    location = errorDetail.Error.TargetSite.DeclaringType.FullName + "." + errorDetail.Error.TargetSite.Name;
+                }*/
+            
+
+#line default
+#line hidden
+
+#line 47 "ErrorPage.cshtml"
+             
+            if (!string.IsNullOrEmpty(location) && firstFrame != null && !string.IsNullOrEmpty(firstFrame.File))
             {
 
 #line default
 #line hidden
 
-            WriteLiteral("                <li id=\"stack\" tabindex=\"1\" class=\"selected\">\r\n                  " +
-"  ");
-#line 72 "ErrorPage.cshtml"
-               Write(Resources.ErrorPageHtml_StackButton);
-
-#line default
-#line hidden
-            WriteLiteral("\r\n                </li>\r\n");
-#line 74 "ErrorPage.cshtml"
-            }
-
-#line default
-#line hidden
-
-            WriteLiteral("            ");
-#line 75 "ErrorPage.cshtml"
-             if (Model.Options.ShowQuery)
-            {
-
-#line default
-#line hidden
-
-            WriteLiteral("                <li id=\"query\" tabindex=\"2\">\r\n                    ");
-#line 78 "ErrorPage.cshtml"
-               Write(Resources.ErrorPageHtml_QueryButton);
-
-#line default
-#line hidden
-            WriteLiteral("\r\n                </li>\r\n");
-#line 80 "ErrorPage.cshtml"
-            }
-
-#line default
-#line hidden
-
-            WriteLiteral("            ");
-#line 81 "ErrorPage.cshtml"
-             if (Model.Options.ShowCookies)
-            {
-
-#line default
-#line hidden
-
-            WriteLiteral("                <li id=\"cookies\" tabindex=\"3\">\r\n                    ");
-#line 84 "ErrorPage.cshtml"
-               Write(Resources.ErrorPageHtml_CookiesButton);
-
-#line default
-#line hidden
-            WriteLiteral("\r\n                </li>\r\n");
-#line 86 "ErrorPage.cshtml"
-            }
-
-#line default
-#line hidden
-
-            WriteLiteral("            ");
-#line 87 "ErrorPage.cshtml"
-             if (Model.Options.ShowHeaders)
-            {
-
-#line default
-#line hidden
-
-            WriteLiteral("                <li id=\"headers\" tabindex=\"4\">\r\n                    ");
-#line 90 "ErrorPage.cshtml"
-               Write(Resources.ErrorPageHtml_HeadersButton);
-
-#line default
-#line hidden
-            WriteLiteral("\r\n                </li>\r\n");
-#line 92 "ErrorPage.cshtml"
-            }
-
-#line default
-#line hidden
-
-            WriteLiteral("            ");
-#line 93 "ErrorPage.cshtml"
-             if (Model.Options.ShowEnvironment)
-            {
-
-#line default
-#line hidden
-
-            WriteLiteral("                <li id=\"environment\" tabindex=\"5\">\r\n                    ");
-#line 96 "ErrorPage.cshtml"
-               Write(Resources.ErrorPageHtml_EnvironmentButton);
-
-#line default
-#line hidden
-            WriteLiteral("\r\n                </li>\r\n");
-#line 98 "ErrorPage.cshtml"
-            }
-
-#line default
-#line hidden
-
-            WriteLiteral("        </ul>\r\n");
-#line 100 "ErrorPage.cshtml"
-        
-
-#line default
-#line hidden
-
-#line 100 "ErrorPage.cshtml"
-         if (Model.Options.ShowExceptionDetails)
-        {
-
-#line default
-#line hidden
-
-            WriteLiteral("            <div id=\"stackpage\" class=\"page\">\r\n                <ul>\r\n");
-#line 104 "ErrorPage.cshtml"
-                    
-
-#line default
-#line hidden
-
-#line 104 "ErrorPage.cshtml"
-                       int tabIndex = 6; 
-
-#line default
-#line hidden
-
-            WriteLiteral("\r\n");
-#line 105 "ErrorPage.cshtml"
-                    
-
-#line default
-#line hidden
-
-#line 105 "ErrorPage.cshtml"
-                     foreach (var errorDetail in Model.ErrorDetails)
-                    {
-
-#line default
-#line hidden
-
-            WriteLiteral("                        <li>\r\n                            <h2 class=\"stackerror\">" +
-"");
-#line 108 "ErrorPage.cshtml"
-                                              Write(errorDetail.Error.GetType().Name);
-
-#line default
-#line hidden
-            WriteLiteral(": ");
-#line 108 "ErrorPage.cshtml"
-                                                                                 Write(errorDetail.Error.Message);
-
-#line default
-#line hidden
-            WriteLiteral("</h2>\r\n                            <ul>\r\n");
-#line 110 "ErrorPage.cshtml"
-                            
-
-#line default
-#line hidden
-
-#line 110 "ErrorPage.cshtml"
-                             foreach (var frame in errorDetail.StackFrames)
-                            {
-
-#line default
-#line hidden
-
-            WriteLiteral("                                <li class=\"frame\"");
-            WriteAttribute("tabindex", Tuple.Create(" tabindex=\"", 4286), Tuple.Create("\"", 4306), 
-            Tuple.Create(Tuple.Create("", 4297), Tuple.Create<System.Object, System.Int32>(tabIndex, 4297), false));
-            WriteLiteral(">\r\n");
-#line 113 "ErrorPage.cshtml"
-                                    
-
-#line default
-#line hidden
-
-#line 113 "ErrorPage.cshtml"
-                                       tabIndex++; 
-
-#line default
-#line hidden
-
-            WriteLiteral("\r\n");
-#line 114 "ErrorPage.cshtml"
-                                    
-
-#line default
-#line hidden
-
-#line 114 "ErrorPage.cshtml"
-                                     if (string.IsNullOrEmpty(frame.File))
-                                    {
-
-#line default
-#line hidden
-
-            WriteLiteral("                                        <h3>");
-#line 116 "ErrorPage.cshtml"
-                                       Write(frame.Function);
-
-#line default
-#line hidden
-            WriteLiteral("</h3>\r\n");
-#line 117 "ErrorPage.cshtml"
-                                    }
-                                    else
-                                    {
-
-#line default
-#line hidden
-
-            WriteLiteral("                                        <h3>");
-#line 120 "ErrorPage.cshtml"
-                                       Write(frame.Function);
+            WriteLiteral("                <p class=\"location\">");
+#line 50 "ErrorPage.cshtml"
+                               Write(location);
 
 #line default
 #line hidden
             WriteLiteral(" in <code");
-            WriteAttribute("title", Tuple.Create(" title=\"", 4733), Tuple.Create("\"", 4752), 
-            Tuple.Create(Tuple.Create("", 4741), Tuple.Create<System.Object, System.Int32>(frame.File, 4741), false));
+            WriteAttribute("title", Tuple.Create(" title=\"", 1895), Tuple.Create("\"", 1919), 
+            Tuple.Create(Tuple.Create("", 1903), Tuple.Create<System.Object, System.Int32>(firstFrame.File, 1903), false));
             WriteLiteral(">");
-#line 120 "ErrorPage.cshtml"
-                                                                                    Write(System.IO.Path.GetFileName(frame.File));
+#line 50 "ErrorPage.cshtml"
+                                                                           Write(System.IO.Path.GetFileName(firstFrame.File));
 
 #line default
 #line hidden
-            WriteLiteral("</code></h3>\r\n");
-#line 121 "ErrorPage.cshtml"
-                                    }
+            WriteLiteral("</code>, line ");
+#line 50 "ErrorPage.cshtml"
+                                                                                                                                     Write(firstFrame.Line);
+
+#line default
+#line hidden
+            WriteLiteral("</p>\r\n");
+#line 51 "ErrorPage.cshtml"
+            }
+            else if (!string.IsNullOrEmpty(location))
+            {
+
+#line default
+#line hidden
+
+            WriteLiteral("                <p class=\"location\">");
+#line 54 "ErrorPage.cshtml"
+                               Write(location);
+
+#line default
+#line hidden
+            WriteLiteral("</p>\r\n");
+#line 55 "ErrorPage.cshtml"
+            }
+            else
+            {
+
+#line default
+#line hidden
+
+            WriteLiteral("                <p class=\"location\">");
+#line 58 "ErrorPage.cshtml"
+                               Write(Resources.ErrorPageHtml_UnknownLocation);
+
+#line default
+#line hidden
+            WriteLiteral("</p>\r\n");
+#line 59 "ErrorPage.cshtml"
+            }
+        }
+
+#line default
+#line hidden
+
+            WriteLiteral("        <ul id=\"header\">\r\n            <li id=\"stack\" tabindex=\"1\" class=\"selected" +
+"\">\r\n                ");
+#line 63 "ErrorPage.cshtml"
+           Write(Resources.ErrorPageHtml_StackButton);
+
+#line default
+#line hidden
+            WriteLiteral("\r\n            </li>\r\n            <li id=\"query\" tabindex=\"2\">\r\n                ");
+#line 66 "ErrorPage.cshtml"
+           Write(Resources.ErrorPageHtml_QueryButton);
+
+#line default
+#line hidden
+            WriteLiteral("\r\n            </li>\r\n            <li id=\"cookies\" tabindex=\"3\">\r\n                " +
+"");
+#line 69 "ErrorPage.cshtml"
+           Write(Resources.ErrorPageHtml_CookiesButton);
+
+#line default
+#line hidden
+            WriteLiteral("\r\n            </li>\r\n            <li id=\"headers\" tabindex=\"4\">\r\n                " +
+"");
+#line 72 "ErrorPage.cshtml"
+           Write(Resources.ErrorPageHtml_HeadersButton);
+
+#line default
+#line hidden
+            WriteLiteral("\r\n            </li>\r\n            <li id=\"environment\" tabindex=\"5\">\r\n            " +
+"    ");
+#line 75 "ErrorPage.cshtml"
+           Write(Resources.ErrorPageHtml_EnvironmentButton);
+
+#line default
+#line hidden
+            WriteLiteral("\r\n            </li>\r\n        </ul>\r\n    \r\n        <div id=\"stackpage\" class=\"page" +
+"\">\r\n            <ul>\r\n");
+#line 81 "ErrorPage.cshtml"
+                
+
+#line default
+#line hidden
+
+#line 81 "ErrorPage.cshtml"
+                   int tabIndex = 6; 
 
 #line default
 #line hidden
 
             WriteLiteral("\r\n");
-#line 123 "ErrorPage.cshtml"
-                                    
+#line 82 "ErrorPage.cshtml"
+                
 
 #line default
 #line hidden
 
-#line 123 "ErrorPage.cshtml"
-                                     if (frame.Line != 0 && frame.ContextCode.Any())
-                                    {
+#line 82 "ErrorPage.cshtml"
+                 foreach (var errorDetail in Model.ErrorDetails)
+                {
 
 #line default
 #line hidden
 
-            WriteLiteral("                                        <div class=\"source\">\r\n");
-#line 126 "ErrorPage.cshtml"
-                                            
+            WriteLiteral("                    <li>\r\n                        <h2 class=\"stackerror\">");
+#line 85 "ErrorPage.cshtml"
+                                          Write(errorDetail.Error.GetType().Name);
+
+#line default
+#line hidden
+            WriteLiteral(": ");
+#line 85 "ErrorPage.cshtml"
+                                                                             Write(errorDetail.Error.Message);
+
+#line default
+#line hidden
+            WriteLiteral("</h2>\r\n                        <ul>\r\n");
+#line 87 "ErrorPage.cshtml"
+                        
 
 #line default
 #line hidden
 
-#line 126 "ErrorPage.cshtml"
-                                             if (frame.PreContextCode != null)
-                                            {
+#line 87 "ErrorPage.cshtml"
+                         foreach (var frame in errorDetail.StackFrames)
+                        {
 
 #line default
 #line hidden
 
-            WriteLiteral("                                                <ol");
-            WriteAttribute("start", Tuple.Create(" start=\"", 5213), Tuple.Create("\"", 5242), 
-            Tuple.Create(Tuple.Create("", 5221), Tuple.Create<System.Object, System.Int32>(frame.PreContextLine, 5221), false));
+            WriteLiteral("                            <li class=\"frame\"");
+            WriteAttribute("tabindex", Tuple.Create(" tabindex=\"", 3454), Tuple.Create("\"", 3474), 
+            Tuple.Create(Tuple.Create("", 3465), Tuple.Create<System.Object, System.Int32>(tabIndex, 3465), false));
+            WriteLiteral(">\r\n");
+#line 90 "ErrorPage.cshtml"
+                                
+
+#line default
+#line hidden
+
+#line 90 "ErrorPage.cshtml"
+                                   tabIndex++; 
+
+#line default
+#line hidden
+
+            WriteLiteral("\r\n");
+#line 91 "ErrorPage.cshtml"
+                                
+
+#line default
+#line hidden
+
+#line 91 "ErrorPage.cshtml"
+                                 if (string.IsNullOrEmpty(frame.File))
+                                {
+
+#line default
+#line hidden
+
+            WriteLiteral("                                    <h3>");
+#line 93 "ErrorPage.cshtml"
+                                   Write(frame.Function);
+
+#line default
+#line hidden
+            WriteLiteral("</h3>\r\n");
+#line 94 "ErrorPage.cshtml"
+                                }
+                                else
+                                {
+
+#line default
+#line hidden
+
+            WriteLiteral("                                    <h3>");
+#line 97 "ErrorPage.cshtml"
+                                   Write(frame.Function);
+
+#line default
+#line hidden
+            WriteLiteral(" in <code");
+            WriteAttribute("title", Tuple.Create(" title=\"", 3869), Tuple.Create("\"", 3888), 
+            Tuple.Create(Tuple.Create("", 3877), Tuple.Create<System.Object, System.Int32>(frame.File, 3877), false));
+            WriteLiteral(">");
+#line 97 "ErrorPage.cshtml"
+                                                                                Write(System.IO.Path.GetFileName(frame.File));
+
+#line default
+#line hidden
+            WriteLiteral("</code></h3>\r\n");
+#line 98 "ErrorPage.cshtml"
+                                }
+
+#line default
+#line hidden
+
+            WriteLiteral("\r\n");
+#line 100 "ErrorPage.cshtml"
+                                
+
+#line default
+#line hidden
+
+#line 100 "ErrorPage.cshtml"
+                                 if (frame.Line != 0 && frame.ContextCode.Any())
+                                {
+
+#line default
+#line hidden
+
+            WriteLiteral("                                    <div class=\"source\">\r\n");
+#line 103 "ErrorPage.cshtml"
+                                        
+
+#line default
+#line hidden
+
+#line 103 "ErrorPage.cshtml"
+                                         if (frame.PreContextCode != null)
+                                        {
+
+#line default
+#line hidden
+
+            WriteLiteral("                                            <ol");
+            WriteAttribute("start", Tuple.Create(" start=\"", 4321), Tuple.Create("\"", 4350), 
+            Tuple.Create(Tuple.Create("", 4329), Tuple.Create<System.Object, System.Int32>(frame.PreContextLine, 4329), false));
             WriteLiteral(" class=\"collapsible\">\r\n");
-#line 129 "ErrorPage.cshtml"
-                                                    
-
-#line default
-#line hidden
-
-#line 129 "ErrorPage.cshtml"
-                                                     foreach (var line in frame.PreContextCode)
-                                                    {
-
-#line default
-#line hidden
-
-            WriteLiteral("                                                        <li><span>");
-#line 131 "ErrorPage.cshtml"
-                                                             Write(line);
-
-#line default
-#line hidden
-            WriteLiteral("</span></li>\r\n");
-#line 132 "ErrorPage.cshtml"
-                                                    }
-
-#line default
-#line hidden
-
-            WriteLiteral("                                                </ol>\r\n");
-#line 134 "ErrorPage.cshtml"
-                                            } 
-
-#line default
-#line hidden
-
-            WriteLiteral("\r\n                                            <ol");
-            WriteAttribute("start", Tuple.Create(" start=\"", 5710), Tuple.Create("\"", 5729), 
-            Tuple.Create(Tuple.Create("", 5718), Tuple.Create<System.Object, System.Int32>(frame.Line, 5718), false));
-            WriteLiteral(" class=\"highlight\">\r\n");
-#line 137 "ErrorPage.cshtml"
+#line 106 "ErrorPage.cshtml"
                                                 
 
 #line default
 #line hidden
 
-#line 137 "ErrorPage.cshtml"
-                                                 foreach (var line in frame.ContextCode)
+#line 106 "ErrorPage.cshtml"
+                                                 foreach (var line in frame.PreContextCode)
                                                 {
 
 #line default
 #line hidden
 
             WriteLiteral("                                                    <li><span>");
-#line 139 "ErrorPage.cshtml"
+#line 108 "ErrorPage.cshtml"
                                                          Write(line);
 
 #line default
 #line hidden
             WriteLiteral("</span></li>\r\n");
-#line 140 "ErrorPage.cshtml"
+#line 109 "ErrorPage.cshtml"
                                                 }
 
 #line default
 #line hidden
 
-            WriteLiteral("                                            </ol>\r\n\r\n");
-#line 143 "ErrorPage.cshtml"
+            WriteLiteral("                                            </ol>\r\n");
+#line 111 "ErrorPage.cshtml"
+                                        } 
+
+#line default
+#line hidden
+
+            WriteLiteral("\r\n                                        <ol");
+            WriteAttribute("start", Tuple.Create(" start=\"", 4790), Tuple.Create("\"", 4809), 
+            Tuple.Create(Tuple.Create("", 4798), Tuple.Create<System.Object, System.Int32>(frame.Line, 4798), false));
+            WriteLiteral(" class=\"highlight\">\r\n");
+#line 114 "ErrorPage.cshtml"
                                             
 
 #line default
 #line hidden
 
-#line 143 "ErrorPage.cshtml"
-                                             if (frame.PostContextCode != null)
+#line 114 "ErrorPage.cshtml"
+                                             foreach (var line in frame.ContextCode)
                                             {
 
 #line default
 #line hidden
 
-            WriteLiteral("                                                <ol");
-            WriteAttribute("start", Tuple.Create(" start=\'", 6256), Tuple.Create("\'", 6281), 
-            Tuple.Create(Tuple.Create("", 6264), Tuple.Create<System.Object, System.Int32>(frame.Line + 1, 6264), false));
-            WriteLiteral(" class=\"collapsible\">\r\n");
-#line 146 "ErrorPage.cshtml"
-                                                    
-
-#line default
-#line hidden
-
-#line 146 "ErrorPage.cshtml"
-                                                     foreach (var line in frame.PostContextCode)
-                                                    {
-
-#line default
-#line hidden
-
-            WriteLiteral("                                                        <li><span>");
-#line 148 "ErrorPage.cshtml"
-                                                             Write(line);
+            WriteLiteral("                                                <li><span>");
+#line 116 "ErrorPage.cshtml"
+                                                     Write(line);
 
 #line default
 #line hidden
             WriteLiteral("</span></li>\r\n");
-#line 149 "ErrorPage.cshtml"
-                                                    }
+#line 117 "ErrorPage.cshtml"
+                                            }
 
 #line default
 #line hidden
 
-            WriteLiteral("                                                </ol>\r\n");
-#line 151 "ErrorPage.cshtml"
-                                            } 
+            WriteLiteral("                                        </ol>\r\n\r\n");
+#line 120 "ErrorPage.cshtml"
+                                        
 
 #line default
 #line hidden
 
-            WriteLiteral("                                        </div>\r\n");
-#line 153 "ErrorPage.cshtml"
-                                    } 
+#line 120 "ErrorPage.cshtml"
+                                         if (frame.PostContextCode != null)
+                                        {
 
 #line default
 #line hidden
 
-            WriteLiteral("                                </li>\r\n");
+            WriteLiteral("                                            <ol");
+            WriteAttribute("start", Tuple.Create(" start=\'", 5304), Tuple.Create("\'", 5329), 
+            Tuple.Create(Tuple.Create("", 5312), Tuple.Create<System.Object, System.Int32>(frame.Line + 1, 5312), false));
+            WriteLiteral(" class=\"collapsible\">\r\n");
+#line 123 "ErrorPage.cshtml"
+                                                
+
+#line default
+#line hidden
+
+#line 123 "ErrorPage.cshtml"
+                                                 foreach (var line in frame.PostContextCode)
+                                                {
+
+#line default
+#line hidden
+
+            WriteLiteral("                                                    <li><span>");
+#line 125 "ErrorPage.cshtml"
+                                                         Write(line);
+
+#line default
+#line hidden
+            WriteLiteral("</span></li>\r\n");
+#line 126 "ErrorPage.cshtml"
+                                                }
+
+#line default
+#line hidden
+
+            WriteLiteral("                                            </ol>\r\n");
+#line 128 "ErrorPage.cshtml"
+                                        } 
+
+#line default
+#line hidden
+
+            WriteLiteral("                                    </div>\r\n");
+#line 130 "ErrorPage.cshtml"
+                                } 
+
+#line default
+#line hidden
+
+            WriteLiteral("                            </li>\r\n");
+#line 132 "ErrorPage.cshtml"
+                        }
+
+#line default
+#line hidden
+
+            WriteLiteral("                        </ul>\r\n                    </li>\r\n");
+#line 135 "ErrorPage.cshtml"
+                }
+
+#line default
+#line hidden
+
+            WriteLiteral("            </ul>\r\n        </div>\r\n       \r\n        <div id=\"querypage\" class=\"pa" +
+"ge\">\r\n");
+#line 140 "ErrorPage.cshtml"
+            
+
+#line default
+#line hidden
+
+#line 140 "ErrorPage.cshtml"
+             if (Model.Query.Any())
+            {
+
+#line default
+#line hidden
+
+            WriteLiteral("                <table>\r\n                    <thead>\r\n                        <tr" +
+">\r\n                            <th>");
+#line 145 "ErrorPage.cshtml"
+                           Write(Resources.ErrorPageHtml_VariableColumn);
+
+#line default
+#line hidden
+            WriteLiteral("</th>\r\n                            <th>");
+#line 146 "ErrorPage.cshtml"
+                           Write(Resources.ErrorPageHtml_ValueColumn);
+
+#line default
+#line hidden
+            WriteLiteral("</th>\r\n                        </tr>\r\n                    </thead>\r\n             " +
+"       <tbody>\r\n");
+#line 150 "ErrorPage.cshtml"
+                        
+
+#line default
+#line hidden
+
+#line 150 "ErrorPage.cshtml"
+                         foreach (var kv in Model.Query.OrderBy(kv => kv.Key))
+                        {
+                            foreach (var v in kv.Value)
+                            {
+
+#line default
+#line hidden
+
+            WriteLiteral("                                <tr>\r\n                                    <td>");
 #line 155 "ErrorPage.cshtml"
-                            }
+                                   Write(kv.Key);
 
 #line default
 #line hidden
+            WriteLiteral("</td>\r\n                                    <td>");
+#line 156 "ErrorPage.cshtml"
+                                   Write(v);
 
-            WriteLiteral("                            </ul>\r\n                        </li>\r\n");
+#line default
+#line hidden
+            WriteLiteral("</td>\r\n                                </tr>\r\n");
 #line 158 "ErrorPage.cshtml"
-                    }
+                            }
+                        }
 
 #line default
 #line hidden
 
-            WriteLiteral("                </ul>\r\n            </div>\r\n");
-#line 161 "ErrorPage.cshtml"
-        }
-
-#line default
-#line hidden
-
-            WriteLiteral("        ");
+            WriteLiteral("                    </tbody>\r\n                </table>\r\n");
 #line 162 "ErrorPage.cshtml"
-         if (Model.Options.ShowQuery)
-        {
+            }
+            else
+            {
 
 #line default
 #line hidden
 
-            WriteLiteral("            <div id=\"querypage\" class=\"page\">\r\n");
+            WriteLiteral("                <p>");
 #line 165 "ErrorPage.cshtml"
-                
+              Write(Resources.ErrorPageHtml_NoQueryStringData);
+
+#line default
+#line hidden
+            WriteLiteral("</p>\r\n");
+#line 166 "ErrorPage.cshtml"
+            }
 
 #line default
 #line hidden
 
-#line 165 "ErrorPage.cshtml"
-                 if (Model.Query.Any())
-                {
-
-#line default
-#line hidden
-
-            WriteLiteral("                    <table>\r\n                        <thead>\r\n                   " +
-"         <tr>\r\n                                <th>");
+            WriteLiteral("        </div>\r\n        \r\n        <div id=\"cookiespage\" class=\"page\">\r\n");
 #line 170 "ErrorPage.cshtml"
-                               Write(Resources.ErrorPageHtml_VariableColumn);
+            
 
 #line default
 #line hidden
-            WriteLiteral("</th>\r\n                                <th>");
-#line 171 "ErrorPage.cshtml"
-                               Write(Resources.ErrorPageHtml_ValueColumn);
+
+#line 170 "ErrorPage.cshtml"
+             if (Model.Cookies.Any())
+            {
 
 #line default
 #line hidden
-            WriteLiteral("</th>\r\n                            </tr>\r\n                        </thead>\r\n     " +
-"                   <tbody>\r\n");
+
+            WriteLiteral("                <table>\r\n                    <thead>\r\n                        <tr" +
+">\r\n                            <th>");
 #line 175 "ErrorPage.cshtml"
-                            
+                           Write(Resources.ErrorPageHtml_VariableColumn);
 
 #line default
 #line hidden
-
-#line 175 "ErrorPage.cshtml"
-                             foreach (var kv in Model.Query.OrderBy(kv => kv.Key))
-                            {
-                                foreach (var v in kv.Value)
-                                {
+            WriteLiteral("</th>\r\n                            <th>");
+#line 176 "ErrorPage.cshtml"
+                           Write(Resources.ErrorPageHtml_ValueColumn);
 
 #line default
 #line hidden
-
-            WriteLiteral("                                    <tr>\r\n                                       " +
-" <td>");
+            WriteLiteral("</th>\r\n                        </tr>\r\n                    </thead>\r\n             " +
+"       <tbody>\r\n");
 #line 180 "ErrorPage.cshtml"
-                                       Write(kv.Key);
+                        
 
 #line default
 #line hidden
-            WriteLiteral("</td>\r\n                                        <td>");
-#line 181 "ErrorPage.cshtml"
-                                       Write(v);
+
+#line 180 "ErrorPage.cshtml"
+                         foreach (var kv in Model.Cookies.OrderBy(kv => kv.Key))
+                        {
 
 #line default
 #line hidden
-            WriteLiteral("</td>\r\n                                    </tr>\r\n");
+
+            WriteLiteral("                            <tr>\r\n                                <td>");
 #line 183 "ErrorPage.cshtml"
-                                }
-                            }
+                               Write(kv.Key);
+
+#line default
+#line hidden
+            WriteLiteral("</td>\r\n                                <td>");
+#line 184 "ErrorPage.cshtml"
+                               Write(kv.Value);
+
+#line default
+#line hidden
+            WriteLiteral("</td>\r\n                            </tr>\r\n");
+#line 186 "ErrorPage.cshtml"
+                        }
 
 #line default
 #line hidden
 
-            WriteLiteral("                        </tbody>\r\n                    </table>\r\n");
-#line 187 "ErrorPage.cshtml"
-                }
-                else
-                {
+            WriteLiteral("                    </tbody>\r\n                </table>\r\n");
+#line 189 "ErrorPage.cshtml"
+            }
+            else
+            {
 
 #line default
 #line hidden
 
-            WriteLiteral("                    <p>");
-#line 190 "ErrorPage.cshtml"
-                  Write(Resources.ErrorPageHtml_NoQueryStringData);
+            WriteLiteral("                <p>");
+#line 192 "ErrorPage.cshtml"
+              Write(Resources.ErrorPageHtml_NoCookieData);
 
 #line default
 #line hidden
             WriteLiteral("</p>\r\n");
-#line 191 "ErrorPage.cshtml"
-                }
-
-#line default
-#line hidden
-
-            WriteLiteral("            </div>\r\n");
 #line 193 "ErrorPage.cshtml"
-        }
+            }
 
 #line default
 #line hidden
 
-            WriteLiteral("        ");
-#line 194 "ErrorPage.cshtml"
-         if (Model.Options.ShowCookies)
-        {
-            /* TODO:
-            <div id="cookiespage" class="page">
-                @if (Model.Cookies.Any())
-                {
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>@Resources.ErrorPageHtml_VariableColumn</th>
-                                <th>@Resources.ErrorPageHtml_ValueColumn</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            @foreach (var kv in Model.Cookies.OrderBy(kv => kv.Key))
+            WriteLiteral("        </div>\r\n        }\r\n        <div id=\"headerspage\" class=\"page\">\r\n");
+#line 197 "ErrorPage.cshtml"
+            
+
+#line default
+#line hidden
+
+#line 197 "ErrorPage.cshtml"
+             if (Model.Headers.Any())
+            {
+
+#line default
+#line hidden
+
+            WriteLiteral("                <table>\r\n                    <thead>\r\n                        <tr" +
+">\r\n                            <th>");
+#line 202 "ErrorPage.cshtml"
+                           Write(Resources.ErrorPageHtml_VariableColumn);
+
+#line default
+#line hidden
+            WriteLiteral("</th>\r\n                            <th>");
+#line 203 "ErrorPage.cshtml"
+                           Write(Resources.ErrorPageHtml_ValueColumn);
+
+#line default
+#line hidden
+            WriteLiteral("</th>\r\n                        </tr>\r\n                    </thead>\r\n             " +
+"       <tbody>\r\n");
+#line 207 "ErrorPage.cshtml"
+                        
+
+#line default
+#line hidden
+
+#line 207 "ErrorPage.cshtml"
+                         foreach (var kv in Model.Headers.OrderBy(kv => kv.Key))
+                        {
+                            foreach (var v in kv.Value)
                             {
-                                <tr>
-                                    <td>@kv.Key</td>
-                                    <td>@kv.Value</td>
-                                </tr>
+
+#line default
+#line hidden
+
+            WriteLiteral("                                <tr>\r\n                                    <td>");
+#line 212 "ErrorPage.cshtml"
+                                   Write(kv.Key);
+
+#line default
+#line hidden
+            WriteLiteral("</td>\r\n                                    <td>");
+#line 213 "ErrorPage.cshtml"
+                                   Write(v);
+
+#line default
+#line hidden
+            WriteLiteral("</td>\r\n                                </tr>\r\n");
+#line 215 "ErrorPage.cshtml"
                             }
-                        </tbody>
-                    </table>
-                }
-                else
-                {
-                    <p>@Resources.ErrorPageHtml_NoCookieData</p>
-                }
-            </div>
-             */
-        }
+                        }
 
 #line default
 #line hidden
 
-            WriteLiteral("        ");
-#line 225 "ErrorPage.cshtml"
-         if (Model.Options.ShowHeaders)
-        {
+            WriteLiteral("                    </tbody>\r\n                </table>\r\n");
+#line 219 "ErrorPage.cshtml"
+            }
+            else
+            {
 
 #line default
 #line hidden
 
-            WriteLiteral("            <div id=\"headerspage\" class=\"page\">\r\n");
-#line 228 "ErrorPage.cshtml"
-                
-
-#line default
-#line hidden
-
-#line 228 "ErrorPage.cshtml"
-                 if (Model.Headers.Any())
-                {
-
-#line default
-#line hidden
-
-            WriteLiteral("                    <table>\r\n                        <thead>\r\n                   " +
-"         <tr>\r\n                                <th>");
-#line 233 "ErrorPage.cshtml"
-                               Write(Resources.ErrorPageHtml_VariableColumn);
-
-#line default
-#line hidden
-            WriteLiteral("</th>\r\n                                <th>");
-#line 234 "ErrorPage.cshtml"
-                               Write(Resources.ErrorPageHtml_ValueColumn);
-
-#line default
-#line hidden
-            WriteLiteral("</th>\r\n                            </tr>\r\n                        </thead>\r\n     " +
-"                   <tbody>\r\n");
-#line 238 "ErrorPage.cshtml"
-                            
-
-#line default
-#line hidden
-
-#line 238 "ErrorPage.cshtml"
-                             foreach (var kv in Model.Headers.OrderBy(kv => kv.Key))
-                            {
-                                foreach (var v in kv.Value)
-                                {
-
-#line default
-#line hidden
-
-            WriteLiteral("                                    <tr>\r\n                                       " +
-" <td>");
-#line 243 "ErrorPage.cshtml"
-                                       Write(kv.Key);
-
-#line default
-#line hidden
-            WriteLiteral("</td>\r\n                                        <td>");
-#line 244 "ErrorPage.cshtml"
-                                       Write(v);
-
-#line default
-#line hidden
-            WriteLiteral("</td>\r\n                                    </tr>\r\n");
-#line 246 "ErrorPage.cshtml"
-                                }
-                            }
-
-#line default
-#line hidden
-
-            WriteLiteral("                        </tbody>\r\n                    </table>\r\n");
-#line 250 "ErrorPage.cshtml"
-                }
-                else
-                {
-
-#line default
-#line hidden
-
-            WriteLiteral("                    <p>");
-#line 253 "ErrorPage.cshtml"
-                  Write(Resources.ErrorPageHtml_NoHeaderData);
+            WriteLiteral("                <p>");
+#line 222 "ErrorPage.cshtml"
+              Write(Resources.ErrorPageHtml_NoHeaderData);
 
 #line default
 #line hidden
             WriteLiteral("</p>\r\n");
-#line 254 "ErrorPage.cshtml"
-                }
+#line 223 "ErrorPage.cshtml"
+            }
 
 #line default
 #line hidden
 
-            WriteLiteral("            </div>\r\n");
-#line 256 "ErrorPage.cshtml"
-        }
+            WriteLiteral("        </div>\r\n        \r\n");
+#line 226 "ErrorPage.cshtml"
+        
 
 #line default
 #line hidden
 
-            WriteLiteral("        ");
-#line 257 "ErrorPage.cshtml"
-         if (Model.Options.ShowEnvironment)
-        {
+#line 226 "ErrorPage.cshtml"
+          
             /* TODO:
             <div id="environmentpage" class="page">
                 <table>
@@ -904,13 +807,13 @@ using Views
                 </table>
             </div>
              */
-        }
+        
 
 #line default
 #line hidden
 
-            WriteLiteral("        <script>\r\n            //<!--\r\n            (function (window, undefined) {\r\n    \"use strict\";\r\n\r\n    function $(selector, element) {\r\n        return new NodeCollection(selector, element);\r\n    }\r\n\r\n    function NodeCollection(selector, element) {\r\n        this.items = [];\r\n        element = element || window.document;\r\n\r\n        var nodeList;\r\n\r\n        if (typeof (selector) === \"string\") {\r\n            nodeList = element.querySelectorAll(selector);\r\n            for (var i = 0, l = nodeList.length; i < l; i++) {\r\n                this.items.push(nodeList.item(i));\r\n            }\r\n        } else if (selector.tagName) {\r\n            this.items.push(selector);\r\n        } else if (selector.splice) {\r\n            this.items = this.items.concat(selector);\r\n        }\r\n    }\r\n\r\n    NodeCollection.prototype = {\r\n        each: function (callback) {\r\n            for (var i = 0, l = this.items.length; i < l; i++) {\r\n                callback(this.items[i], i);\r\n            }\r\n            return this;\r\n        },\r\n\r\n        children: function (selector) {\r\n            var children = [];\r\n\r\n            this.each(function (el) {\r\n                children = children.concat($(selector, el).items);\r\n            });\r\n\r\n            return $(children);\r\n        },\r\n\r\n        hide: function () {\r\n            this.each(function (el) {\r\n                el.style.display = \"none\";\r\n            });\r\n\r\n            return this;\r\n        },\r\n\r\n        toggle: function () {\r\n            this.each(function (el) {\r\n                el.style.display = el.style.display === \"none\" ? \"\" : \"none\";\r\n            });\r\n\r\n            return this;\r\n        },\r\n\r\n        show: function () {\r\n            this.each(function (el) {\r\n                el.style.display = \"\";\r\n            });\r\n\r\n            return this;\r\n        },\r\n\r\n        addClass: function (className) {\r\n            this.each(function (el) {\r\n                var existingClassName = el.className,\r\n                    classNames;\r\n                if (!existingClassName) {\r\n                    el.className = className;\r\n                } else {\r\n                    classNames = existingClassName.split(\" \");\r\n                    if (classNames.indexOf(className) < 0) {\r\n                        el.className = existingClassName + \" \" + className;\r\n                    }\r\n                }\r\n            });\r\n\r\n            return this;\r\n        },\r\n\r\n        removeClass: function (className) {\r\n            this.each(function (el) {\r\n                var existingClassName = el.className,\r\n                    classNames, index;\r\n                if (existingClassName === className) {\r\n                    el.className = \"\";\r\n                } else if (existingClassName) {\r\n                    classNames = existingClassName.split(\" \");\r\n                    index = classNames.indexOf(className);\r\n                    if (index > 0) {\r\n                        classNames.splice(index, 1);\r\n                        el.className = classNames.join(\" \");\r\n                    }\r\n                }\r\n            });\r\n\r\n            return this;\r\n        },\r\n\r\n        toggleClass: function (className) {\r\n            this.each(function (el) {\r\n                var classNames = el.className.split(\" \");\r\n                if (classNames.indexOf(className) >= 0) {\r\n                    $(el).removeClass(className);\r\n                } else {\r\n                    $(el).addClass(className);\r\n                }\r\n            });\r\n\r\n            return this;\r\n        },\r\n\r\n        attr: function (name) {\r\n            if (this.items.length === 0) {\r\n                return null;\r\n            }\r\n\r\n            return this.items[0].getAttribute(name);\r\n        },\r\n\r\n        on: function (eventName, handler) {\r\n            this.each(function (el, idx) {\r\n                var callback = function (e) {\r\n                    e = e || window.event;\r\n                    if (!e.which && e.keyCode) {\r\n                        e.which = e.keyCode; // Normalize IE8 key events\r\n                    }\r\n                    handler.apply(el, [e]);\r\n                };\r\n\r\n                if (el.addEventListener) { // DOM Events\r\n                    el.addEventListener(eventName, callback, false);\r\n                } else if (el.attachEvent) { // IE8 events\r\n                    el.attachEvent(\"on\" + eventName, callback);\r\n                } else {\r\n                    el[\"on\" + type] = callback;\r\n                }\r\n            });\r\n\r\n            return this;\r\n        },\r\n\r\n        click: function (handler) {\r\n            return this.on(\"click\", handler);\r\n        },\r\n\r\n        keypress: function (handler) {\r\n            return this.on(\"keypress\", handler);\r\n        }\r\n    };\r\n\r\n    function frame(el) {\r\n        $(el).children(\".source .collapsible\").toggle();\r\n    }\r\n\r\n    function tab(el) {\r\n        var unselected = $(\"#header .selected\").removeClass(\"selected\").attr(\"id\");\r\n        var selected = $(el).addClass(\"selected\").attr(\"id\");\r\n\r\n        $(\"#\" + unselected + \"page\").hide();\r\n        $(\"#\" + selected + \"page\").show();\r\n    }\r\n\r\n    $(\".collapsible\").hide();\r\n    $(\".page\").hide();\r\n    $(\"#stackpage\").show();\r\n\r\n    $(\".frame\")\r\n        .click(function () {\r\n            frame(this);\r\n        })\r\n        .keypress(function (e) {\r\n            if (e.which === 13) {\r\n                frame(this);\r\n            }\r\n        });\r\n\r\n    $(\"#header li\")\r\n        .click(function () {\r\n            tab(this);\r\n        })\r\n        .keypress(function (e) {\r\n            if (e.which === 13) {\r\n                tab(this);\r\n            }\r\n        });\r\n})(window);\r\n " +
-"           //-->\r\n        </script>\r\n    </body>\r\n</html>\r\n");
+            WriteLiteral("\r\n        <script>\r\n            //<!--\r\n            (function (window, undefined) {\r\n    \"use strict\";\r\n\r\n    function $(selector, element) {\r\n        return new NodeCollection(selector, element);\r\n    }\r\n\r\n    function NodeCollection(selector, element) {\r\n        this.items = [];\r\n        element = element || window.document;\r\n\r\n        var nodeList;\r\n\r\n        if (typeof (selector) === \"string\") {\r\n            nodeList = element.querySelectorAll(selector);\r\n            for (var i = 0, l = nodeList.length; i < l; i++) {\r\n                this.items.push(nodeList.item(i));\r\n            }\r\n        } else if (selector.tagName) {\r\n            this.items.push(selector);\r\n        } else if (selector.splice) {\r\n            this.items = this.items.concat(selector);\r\n        }\r\n    }\r\n\r\n    NodeCollection.prototype = {\r\n        each: function (callback) {\r\n            for (var i = 0, l = this.items.length; i < l; i++) {\r\n                callback(this.items[i], i);\r\n            }\r\n            return this;\r\n        },\r\n\r\n        children: function (selector) {\r\n            var children = [];\r\n\r\n            this.each(function (el) {\r\n                children = children.concat($(selector, el).items);\r\n            });\r\n\r\n            return $(children);\r\n        },\r\n\r\n        hide: function () {\r\n            this.each(function (el) {\r\n                el.style.display = \"none\";\r\n            });\r\n\r\n            return this;\r\n        },\r\n\r\n        toggle: function () {\r\n            this.each(function (el) {\r\n                el.style.display = el.style.display === \"none\" ? \"\" : \"none\";\r\n            });\r\n\r\n            return this;\r\n        },\r\n\r\n        show: function () {\r\n            this.each(function (el) {\r\n                el.style.display = \"\";\r\n            });\r\n\r\n            return this;\r\n        },\r\n\r\n        addClass: function (className) {\r\n            this.each(function (el) {\r\n                var existingClassName = el.className,\r\n                    classNames;\r\n                if (!existingClassName) {\r\n                    el.className = className;\r\n                } else {\r\n                    classNames = existingClassName.split(\" \");\r\n                    if (classNames.indexOf(className) < 0) {\r\n                        el.className = existingClassName + \" \" + className;\r\n                    }\r\n                }\r\n            });\r\n\r\n            return this;\r\n        },\r\n\r\n        removeClass: function (className) {\r\n            this.each(function (el) {\r\n                var existingClassName = el.className,\r\n                    classNames, index;\r\n                if (existingClassName === className) {\r\n                    el.className = \"\";\r\n                } else if (existingClassName) {\r\n                    classNames = existingClassName.split(\" \");\r\n                    index = classNames.indexOf(className);\r\n                    if (index > 0) {\r\n                        classNames.splice(index, 1);\r\n                        el.className = classNames.join(\" \");\r\n                    }\r\n                }\r\n            });\r\n\r\n            return this;\r\n        },\r\n\r\n        toggleClass: function (className) {\r\n            this.each(function (el) {\r\n                var classNames = el.className.split(\" \");\r\n                if (classNames.indexOf(className) >= 0) {\r\n                    $(el).removeClass(className);\r\n                } else {\r\n                    $(el).addClass(className);\r\n                }\r\n            });\r\n\r\n            return this;\r\n        },\r\n\r\n        attr: function (name) {\r\n            if (this.items.length === 0) {\r\n                return null;\r\n            }\r\n\r\n            return this.items[0].getAttribute(name);\r\n        },\r\n\r\n        on: function (eventName, handler) {\r\n            this.each(function (el, idx) {\r\n                var callback = function (e) {\r\n                    e = e || window.event;\r\n                    if (!e.which && e.keyCode) {\r\n                        e.which = e.keyCode; // Normalize IE8 key events\r\n                    }\r\n                    handler.apply(el, [e]);\r\n                };\r\n\r\n                if (el.addEventListener) { // DOM Events\r\n                    el.addEventListener(eventName, callback, false);\r\n                } else if (el.attachEvent) { // IE8 events\r\n                    el.attachEvent(\"on\" + eventName, callback);\r\n                } else {\r\n                    el[\"on\" + type] = callback;\r\n                }\r\n            });\r\n\r\n            return this;\r\n        },\r\n\r\n        click: function (handler) {\r\n            return this.on(\"click\", handler);\r\n        },\r\n\r\n        keypress: function (handler) {\r\n            return this.on(\"keypress\", handler);\r\n        }\r\n    };\r\n\r\n    function frame(el) {\r\n        $(el).children(\".source .collapsible\").toggle();\r\n    }\r\n\r\n    function tab(el) {\r\n        var unselected = $(\"#header .selected\").removeClass(\"selected\").attr(\"id\");\r\n        var selected = $(el).addClass(\"selected\").attr(\"id\");\r\n\r\n        $(\"#\" + unselected + \"page\").hide();\r\n        $(\"#\" + selected + \"page\").show();\r\n    }\r\n\r\n    $(\".collapsible\").hide();\r\n    $(\".page\").hide();\r\n    $(\"#stackpage\").show();\r\n\r\n    $(\".frame\")\r\n        .click(function () {\r\n            frame(this);\r\n        })\r\n        .keypress(function (e) {\r\n            if (e.which === 13) {\r\n                frame(this);\r\n            }\r\n        });\r\n\r\n    $(\"#header li\")\r\n        .click(function () {\r\n            tab(this);\r\n        })\r\n        .keypress(function (e) {\r\n            if (e.which === 13) {\r\n                tab(this);\r\n            }\r\n        });\r\n})(window);\r" +
+"\n            //-->\r\n        </script>\r\n    </body>\r\n</html>\r\n");
         }
         #pragma warning restore 1998
     }

--- a/src/Microsoft.AspNet.Diagnostics/Views/ErrorPage.cshtml
+++ b/src/Microsoft.AspNet.Diagnostics/Views/ErrorPage.cshtml
@@ -30,232 +30,200 @@
     </head>
     <body>
         <h1>@Resources.ErrorPageHtml_UnhandledException</h1>
-        @if (Model.Options.ShowExceptionDetails)
+        @foreach (var errorDetail in Model.ErrorDetails)
         {
-            foreach (var errorDetail in Model.ErrorDetails)
-            {
-                <div class="titleerror">@errorDetail.Error.GetType().Name: @{ Output.Write(HtmlEncodeAndReplaceLineBreaks(errorDetail.Error.Message)); }</div>
-                @{
-                    StackFrame firstFrame = null;
-                    firstFrame = errorDetail.StackFrames.FirstOrDefault();
-                    if (firstFrame != null)
-                    {
-                        location = firstFrame.Function;
-                    }/* TODO: TargetSite is not defined
-                    else if (errorDetail.Error.TargetSite != null && errorDetail.Error.TargetSite.DeclaringType != null)
-                    {
-                        location = errorDetail.Error.TargetSite.DeclaringType.FullName + "." + errorDetail.Error.TargetSite.Name;
-                    }*/
-                }
-                if (!string.IsNullOrEmpty(location) && firstFrame != null && !string.IsNullOrEmpty(firstFrame.File))
+            <div class="titleerror">@errorDetail.Error.GetType().Name: @{ Output.Write(HtmlEncodeAndReplaceLineBreaks(errorDetail.Error.Message)); }</div>
+            @{
+                StackFrame firstFrame = null;
+                firstFrame = errorDetail.StackFrames.FirstOrDefault();
+                if (firstFrame != null)
                 {
-                    <p class="location">@location in <code title="@firstFrame.File">@System.IO.Path.GetFileName(firstFrame.File)</code>, line @firstFrame.Line</p>
-                }
-                else if (!string.IsNullOrEmpty(location))
+                    location = firstFrame.Function;
+                }/* TODO: TargetSite is not defined
+                else if (errorDetail.Error.TargetSite != null && errorDetail.Error.TargetSite.DeclaringType != null)
                 {
-                    <p class="location">@location</p>
-                }
-                else
-                {
-                    <p class="location">@Resources.ErrorPageHtml_UnknownLocation</p>
-                }
+                    location = errorDetail.Error.TargetSite.DeclaringType.FullName + "." + errorDetail.Error.TargetSite.Name;
+                }*/
             }
-        }
-        else
-        {
-            <h2>@Resources.ErrorPageHtml_EnableShowExceptions</h2>
+            if (!string.IsNullOrEmpty(location) && firstFrame != null && !string.IsNullOrEmpty(firstFrame.File))
+            {
+                <p class="location">@location in <code title="@firstFrame.File">@System.IO.Path.GetFileName(firstFrame.File)</code>, line @firstFrame.Line</p>
+            }
+            else if (!string.IsNullOrEmpty(location))
+            {
+                <p class="location">@location</p>
+            }
+            else
+            {
+                <p class="location">@Resources.ErrorPageHtml_UnknownLocation</p>
+            }
         }
         <ul id="header">
-            @if (Model.Options.ShowExceptionDetails)
-            {
-                <li id="stack" tabindex="1" class="selected">
-                    @Resources.ErrorPageHtml_StackButton
-                </li>
-            }
-            @if (Model.Options.ShowQuery)
-            {
-                <li id="query" tabindex="2">
-                    @Resources.ErrorPageHtml_QueryButton
-                </li>
-            }
-            @if (Model.Options.ShowCookies)
-            {
-                <li id="cookies" tabindex="3">
-                    @Resources.ErrorPageHtml_CookiesButton
-                </li>
-            }
-            @if (Model.Options.ShowHeaders)
-            {
-                <li id="headers" tabindex="4">
-                    @Resources.ErrorPageHtml_HeadersButton
-                </li>
-            }
-            @if (Model.Options.ShowEnvironment)
-            {
-                <li id="environment" tabindex="5">
-                    @Resources.ErrorPageHtml_EnvironmentButton
-                </li>
-            }
+            <li id="stack" tabindex="1" class="selected">
+                @Resources.ErrorPageHtml_StackButton
+            </li>
+            <li id="query" tabindex="2">
+                @Resources.ErrorPageHtml_QueryButton
+            </li>
+            <li id="cookies" tabindex="3">
+                @Resources.ErrorPageHtml_CookiesButton
+            </li>
+            <li id="headers" tabindex="4">
+                @Resources.ErrorPageHtml_HeadersButton
+            </li>
+            <li id="environment" tabindex="5">
+                @Resources.ErrorPageHtml_EnvironmentButton
+            </li>
         </ul>
-        @if (Model.Options.ShowExceptionDetails)
-        {
-            <div id="stackpage" class="page">
-                <ul>
-                    @{ int tabIndex = 6; }
-                    @foreach (var errorDetail in Model.ErrorDetails)
-                    {
-                        <li>
-                            <h2 class="stackerror">@errorDetail.Error.GetType().Name: @errorDetail.Error.Message</h2>
-                            <ul>
-                            @foreach (var frame in errorDetail.StackFrames)
-                            {
-                                <li class="frame" tabindex="@tabIndex">
-                                    @{ tabIndex++; }
-                                    @if (string.IsNullOrEmpty(frame.File))
-                                    {
-                                        <h3>@frame.Function</h3>
-                                    }
-                                    else
-                                    {
-                                        <h3>@frame.Function in <code title="@frame.File">@System.IO.Path.GetFileName(frame.File)</code></h3>
-                                    }
+    
+        <div id="stackpage" class="page">
+            <ul>
+                @{ int tabIndex = 6; }
+                @foreach (var errorDetail in Model.ErrorDetails)
+                {
+                    <li>
+                        <h2 class="stackerror">@errorDetail.Error.GetType().Name: @errorDetail.Error.Message</h2>
+                        <ul>
+                        @foreach (var frame in errorDetail.StackFrames)
+                        {
+                            <li class="frame" tabindex="@tabIndex">
+                                @{ tabIndex++; }
+                                @if (string.IsNullOrEmpty(frame.File))
+                                {
+                                    <h3>@frame.Function</h3>
+                                }
+                                else
+                                {
+                                    <h3>@frame.Function in <code title="@frame.File">@System.IO.Path.GetFileName(frame.File)</code></h3>
+                                }
 
-                                    @if (frame.Line != 0 && frame.ContextCode.Any())
-                                    {
-                                        <div class="source">
-                                            @if (frame.PreContextCode != null)
-                                            {
-                                                <ol start="@frame.PreContextLine" class="collapsible">
-                                                    @foreach (var line in frame.PreContextCode)
-                                                    {
-                                                        <li><span>@line</span></li>
-                                                    }
-                                                </ol>
-                                            } 
-
-                                            <ol start="@frame.Line" class="highlight">
-                                                @foreach (var line in frame.ContextCode)
+                                @if (frame.Line != 0 && frame.ContextCode.Any())
+                                {
+                                    <div class="source">
+                                        @if (frame.PreContextCode != null)
+                                        {
+                                            <ol start="@frame.PreContextLine" class="collapsible">
+                                                @foreach (var line in frame.PreContextCode)
                                                 {
                                                     <li><span>@line</span></li>
                                                 }
                                             </ol>
+                                        } 
 
-                                            @if (frame.PostContextCode != null)
+                                        <ol start="@frame.Line" class="highlight">
+                                            @foreach (var line in frame.ContextCode)
                                             {
-                                                <ol start='@(frame.Line + 1)' class="collapsible">
-                                                    @foreach (var line in frame.PostContextCode)
-                                                    {
-                                                        <li><span>@line</span></li>
-                                                    }
-                                                </ol>
-                                            } 
-                                        </div>
-                                    } 
-                                </li>
-                            }
-                            </ul>
-                        </li>
-                    }
-                </ul>
-            </div>
-        }
-        @if (Model.Options.ShowQuery)
-        {
-            <div id="querypage" class="page">
-                @if (Model.Query.Any())
-                {
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>@Resources.ErrorPageHtml_VariableColumn</th>
-                                <th>@Resources.ErrorPageHtml_ValueColumn</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            @foreach (var kv in Model.Query.OrderBy(kv => kv.Key))
-                            {
-                                foreach (var v in kv.Value)
-                                {
-                                    <tr>
-                                        <td>@kv.Key</td>
-                                        <td>@v</td>
-                                    </tr>
-                                }
-                            }
-                        </tbody>
-                    </table>
+                                                <li><span>@line</span></li>
+                                            }
+                                        </ol>
+
+                                        @if (frame.PostContextCode != null)
+                                        {
+                                            <ol start='@(frame.Line + 1)' class="collapsible">
+                                                @foreach (var line in frame.PostContextCode)
+                                                {
+                                                    <li><span>@line</span></li>
+                                                }
+                                            </ol>
+                                        } 
+                                    </div>
+                                } 
+                            </li>
+                        }
+                        </ul>
+                    </li>
                 }
-                else
-                {
-                    <p>@Resources.ErrorPageHtml_NoQueryStringData</p>
-                }
-            </div>
-        }
-        @if (Model.Options.ShowCookies)
-        {
-            /* TODO:
-            <div id="cookiespage" class="page">
-                @if (Model.Cookies.Any())
-                {
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>@Resources.ErrorPageHtml_VariableColumn</th>
-                                <th>@Resources.ErrorPageHtml_ValueColumn</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            @foreach (var kv in Model.Cookies.OrderBy(kv => kv.Key))
+            </ul>
+        </div>
+       
+        <div id="querypage" class="page">
+            @if (Model.Query.Any())
+            {
+                <table>
+                    <thead>
+                        <tr>
+                            <th>@Resources.ErrorPageHtml_VariableColumn</th>
+                            <th>@Resources.ErrorPageHtml_ValueColumn</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var kv in Model.Query.OrderBy(kv => kv.Key))
+                        {
+                            foreach (var v in kv.Value)
                             {
                                 <tr>
                                     <td>@kv.Key</td>
-                                    <td>@kv.Value</td>
+                                    <td>@v</td>
                                 </tr>
                             }
-                        </tbody>
-                    </table>
-                }
-                else
-                {
-                    <p>@Resources.ErrorPageHtml_NoCookieData</p>
-                }
-            </div>
-             */
-        }
-        @if (Model.Options.ShowHeaders)
-        {
-            <div id="headerspage" class="page">
-                @if (Model.Headers.Any())
-                {
-                    <table>
-                        <thead>
+                        }
+                    </tbody>
+                </table>
+            }
+            else
+            {
+                <p>@Resources.ErrorPageHtml_NoQueryStringData</p>
+            }
+        </div>
+        
+        <div id="cookiespage" class="page">
+            @if (Model.Cookies.Any())
+            {
+                <table>
+                    <thead>
+                        <tr>
+                            <th>@Resources.ErrorPageHtml_VariableColumn</th>
+                            <th>@Resources.ErrorPageHtml_ValueColumn</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var kv in Model.Cookies.OrderBy(kv => kv.Key))
+                        {
                             <tr>
-                                <th>@Resources.ErrorPageHtml_VariableColumn</th>
-                                <th>@Resources.ErrorPageHtml_ValueColumn</th>
+                                <td>@kv.Key</td>
+                                <td>@kv.Value</td>
                             </tr>
-                        </thead>
-                        <tbody>
-                            @foreach (var kv in Model.Headers.OrderBy(kv => kv.Key))
-                            {
-                                foreach (var v in kv.Value)
-                                {
-                                    <tr>
-                                        <td>@kv.Key</td>
-                                        <td>@v</td>
-                                    </tr>
-                                }
-                            }
-                        </tbody>
-                    </table>
-                }
-                else
-                {
-                    <p>@Resources.ErrorPageHtml_NoHeaderData</p>
-                }
-            </div>
+                        }
+                    </tbody>
+                </table>
+            }
+            else
+            {
+                <p>@Resources.ErrorPageHtml_NoCookieData</p>
+            }
+        </div>
         }
-        @if (Model.Options.ShowEnvironment)
-        {
+        <div id="headerspage" class="page">
+            @if (Model.Headers.Any())
+            {
+                <table>
+                    <thead>
+                        <tr>
+                            <th>@Resources.ErrorPageHtml_VariableColumn</th>
+                            <th>@Resources.ErrorPageHtml_ValueColumn</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var kv in Model.Headers.OrderBy(kv => kv.Key))
+                        {
+                            foreach (var v in kv.Value)
+                            {
+                                <tr>
+                                    <td>@kv.Key</td>
+                                    <td>@v</td>
+                                </tr>
+                            }
+                        }
+                    </tbody>
+                </table>
+            }
+            else
+            {
+                <p>@Resources.ErrorPageHtml_NoHeaderData</p>
+            }
+        </div>
+        
+        @{
             /* TODO:
             <div id="environmentpage" class="page">
                 <table>

--- a/src/Microsoft.AspNet.Diagnostics/Views/ErrorPageModel.cs
+++ b/src/Microsoft.AspNet.Diagnostics/Views/ErrorPageModel.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 
-using System;
 using System.Collections.Generic;
 using Microsoft.AspNet.Http;
 
@@ -19,28 +18,28 @@ namespace Microsoft.AspNet.Diagnostics.Views
         public ErrorPageOptions Options { get; set; }
 
         /// <summary>
-        /// Detailed information about each exception in the stack
+        /// Detailed information about each exception in the stack.
         /// </summary>
         public IEnumerable<ErrorDetails> ErrorDetails { get; set; }
 
         /// <summary>
-        /// Parsed query data
+        /// Parsed query data.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly", Justification = "Model class contains collection")]
         public IReadableStringCollection Query { get; set; }
-
-        /* TODO:
+        
         /// <summary>
-        /// Request cookies
+        /// Request cookies.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly", Justification = "Model class contains collection")]
-        public RequestCookieCollection Cookies { get; set; }
-        */
+        public IReadableStringCollection Cookies { get; set; }
+        
         /// <summary>
-        /// Request headers
+        /// Request headers.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly", Justification = "Model class contains collection")]
         public IDictionary<string, string[]> Headers { get; set; }
+
         /* TODO:
         /// <summary>
         /// The request environment

--- a/src/PageGenerator/project.json
+++ b/src/PageGenerator/project.json
@@ -1,17 +1,21 @@
 {
-    "version": "1.0.0-*",
-    "dependencies": {
-        "Microsoft.AspNet.Diagnostics.Elm": "1.0.0-*",
-        "Microsoft.AspNet.Diagnostics.Entity": "7.0.0-*",
-        "Microsoft.AspNet.Razor": "4.0.0-*"
-    },
+  "version": "1.0.0-*",
+  "dependencies": {
+    "Microsoft.AspNet.Diagnostics.Elm": "1.0.0-*",
+    "Microsoft.AspNet.Diagnostics.Entity": "7.0.0-*",
+    "Microsoft.AspNet.Razor": "4.0.0-*"
+  },
 
-    "frameworks": {
-        "dnx451": { },
-        "dnxcore50": {
-            "dependencies": {
-                "System.Console": "4.0.0-beta-*"
-            }
-        }
+  "frameworks": {
+    "dnx451": { },
+    "dnxcore50": {
+      "dependencies": {
+        "System.Console": "4.0.0-beta-*"
+      }
     }
+  },
+  
+  "commands": {
+    "run" : "PageGenerator"
+  }
 }


### PR DESCRIPTION
Start of refactoring out the `ErrorPageOptions`

- Removed all properties except `SourceCodeLineCount`
- Updated ErroPageMiddleware (including some minor code-style changes)
- Updated CompilationErrorPage.cshtml and ErrorPage.cshtml
- Added `run` command to PageGenerator project.json to execute from command line

#142