### PR TITLE
:bug: No database error page for existing databases

### DIFF
--- a/src/Microsoft.AspNet.Diagnostics.Entity/DatabaseErrorPageMiddleware.cs
+++ b/src/Microsoft.AspNet.Diagnostics.Entity/DatabaseErrorPageMiddleware.cs
@@ -92,7 +92,12 @@ namespace Microsoft.AspNet.Diagnostics.Entity
                                         select m.Key)
                                     .ToList();
 
-                                var pendingModelChanges = modelDiffer.HasDifferences(migrationsAssembly.ModelSnapshot?.Model, dbContext.Model);
+                                // HasDifferences will return true if there is no model snapshot, but if there is an existing database
+                                // and no model snapshot then we don't want to show the error page since they are most likely targeting
+                                // and existing database and have just misconfigured their model
+                                var pendingModelChanges = migrationsAssembly.ModelSnapshot == null && databaseExists
+                                    ? false
+                                    : modelDiffer.HasDifferences(migrationsAssembly.ModelSnapshot?.Model, dbContext.Model);
 
                                 if ((!databaseExists && pendingMigrations.Any()) || pendingMigrations.Any() || pendingModelChanges)
                                 {


### PR DESCRIPTION
When there is an existing database and no migrations are present, then we should just display the standard error page as they are not using migrations and need to adjust their mapping code to match the existing schema.
Resolve #182