### PR TITLE
Skip LocalDb dependent test on Mono

### DIFF
--- a/test/Microsoft.AspNet.Diagnostics.Entity.FunctionalTests/DatabaseErrorPageMiddlewareTest.cs
+++ b/test/Microsoft.AspNet.Diagnostics.Entity.FunctionalTests/DatabaseErrorPageMiddlewareTest.cs
@@ -281,7 +281,8 @@ namespace Microsoft.AspNet.Diagnostics.Entity.Tests
             }
         }
 
-        [Fact]
+        [ConditionalTheory]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task Pass_thru_when_context_not_in_services()
         {
             using (var database = SqlServerTestStore.CreateScratch())


### PR DESCRIPTION
Some tests rely on LocalDb and therefore do not run on Mac/Linux. We
have https://github.com/aspnet/Diagnostics/issues/176 open to address
this, but in the meantime some of the tests are skipped. Adding one more
test that we missed.