### PR TITLE
Skip tests that rely on back slashes as part separator on Linux

### DIFF
--- a/test/Microsoft.AspNet.Diagnostics.Tests/DeveloperExceptionPageMiddlewareTest.cs
+++ b/test/Microsoft.AspNet.Diagnostics.Tests/DeveloperExceptionPageMiddlewareTest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNet.Diagnostics
                     "TestFiles/SourceFile.txt"
                 };
 
-                if (!TestPlatformHelper.IsMono)
+                if (!TestPlatformHelper.IsLinux)
                 {
                     data.Add(@"TestFiles\SourceFile.txt");
                 }


### PR DESCRIPTION
Fixes #191