### PR TITLE
Fix package dependencies

### DIFF
--- a/DiagnosticsPages.sln
+++ b/DiagnosticsPages.sln
@@ -51,6 +51,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNetCore.Middle
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNetCore.Diagnostics.FunctionalTests", "test\Microsoft.AspNetCore.Diagnostics.FunctionalTests\Microsoft.AspNetCore.Diagnostics.FunctionalTests.xproj", "{BFDFE1E3-A6A9-4DAB-8939-1DA306FC69C8}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNetCore.DiagnosticsViewPage.Sources", "src\Microsoft.AspNetCore.DiagnosticsViewPage.Sources\Microsoft.AspNetCore.DiagnosticsViewPage.Sources.xproj", "{B9F08060-621F-4E1F-BDA8-9C4EA107E08A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -275,6 +277,18 @@ Global
 		{BFDFE1E3-A6A9-4DAB-8939-1DA306FC69C8}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{BFDFE1E3-A6A9-4DAB-8939-1DA306FC69C8}.Release|x86.ActiveCfg = Release|Any CPU
 		{BFDFE1E3-A6A9-4DAB-8939-1DA306FC69C8}.Release|x86.Build.0 = Release|Any CPU
+		{B9F08060-621F-4E1F-BDA8-9C4EA107E08A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B9F08060-621F-4E1F-BDA8-9C4EA107E08A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B9F08060-621F-4E1F-BDA8-9C4EA107E08A}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{B9F08060-621F-4E1F-BDA8-9C4EA107E08A}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{B9F08060-621F-4E1F-BDA8-9C4EA107E08A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B9F08060-621F-4E1F-BDA8-9C4EA107E08A}.Debug|x86.Build.0 = Debug|Any CPU
+		{B9F08060-621F-4E1F-BDA8-9C4EA107E08A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B9F08060-621F-4E1F-BDA8-9C4EA107E08A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B9F08060-621F-4E1F-BDA8-9C4EA107E08A}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{B9F08060-621F-4E1F-BDA8-9C4EA107E08A}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{B9F08060-621F-4E1F-BDA8-9C4EA107E08A}.Release|x86.ActiveCfg = Release|Any CPU
+		{B9F08060-621F-4E1F-BDA8-9C4EA107E08A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -299,5 +313,6 @@ Global
 		{95981429-F212-44E1-83AA-32DA9E2A517C} = {ACAA0157-A8C4-4152-93DE-90CCDF304087}
 		{B0166AED-738F-42EE-AF4D-C487C8B21521} = {2AF90579-B118-4583-AE88-672EFACB5BC4}
 		{BFDFE1E3-A6A9-4DAB-8939-1DA306FC69C8} = {2AF90579-B118-4583-AE88-672EFACB5BC4}
+		{B9F08060-621F-4E1F-BDA8-9C4EA107E08A} = {509A6F36-AD80-4A18-B5B1-717D38DFF29D}
 	EndGlobalSection
 EndGlobal

--- a/NuGetPackageVerifier.json
+++ b/NuGetPackageVerifier.json
@@ -14,6 +14,7 @@
     "adx-nonshipping": {
         "rules": [],
         "packages": {
+            "Microsoft.AspNetCore.DiagnosticsViewPage.Sources": { },
             "PageGenerator": { }
         }
     },

--- a/samples/DatabaseErrorPageSample/project.json
+++ b/samples/DatabaseErrorPageSample/project.json
@@ -1,10 +1,11 @@
 {
   "dependencies": {
+    "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",
     "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": "1.0.0-*",
     "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.EntityFrameworkCore.SqlServer": "1.0.0-*",
     "Microsoft.EntityFrameworkCore.Commands": "1.0.0-*",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.NETCore.Platforms": "1.0.1-*"
   },
   "compilationOptions": {

--- a/src/Microsoft.AspNetCore.Diagnostics.Elm/Views/DetailsPage.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics.Elm/Views/DetailsPage.cs
@@ -25,13 +25,13 @@ using Microsoft.AspNetCore.Diagnostics.Elm
 #line hidden
     ;
 #line 5 "DetailsPage.cshtml"
-using Microsoft.AspNetCore.Diagnostics.Views
+using Microsoft.AspNetCore.Diagnostics.Elm.Views
 
 #line default
 #line hidden
     ;
 #line 6 "DetailsPage.cshtml"
-using Microsoft.AspNetCore.Diagnostics.Elm.Views
+using Microsoft.AspNetCore.DiagnosticsViewPage.Views
 
 #line default
 #line hidden
@@ -44,7 +44,7 @@ using Microsoft.Extensions.Logging
     ;
     using System.Threading.Tasks;
 
-    public class DetailsPage : Microsoft.AspNetCore.Diagnostics.Views.BaseView
+    public class DetailsPage : Microsoft.AspNetCore.DiagnosticsViewPage.Views.BaseView
     {
 #line 10 "DetailsPage.cshtml"
 
@@ -423,9 +423,9 @@ using Microsoft.Extensions.Logging
 #line hidden
 
             WriteLiteral("                    <option");
-            BeginWriteAttribute("value", " value=\"", 7715, "\"", 7735, 1);
+            BeginWriteAttribute("value", " value=\"", 7723, "\"", 7743, 1);
 #line 226 "DetailsPage.cshtml"
-WriteAttributeValue("", 7723, severityInt, 7723, 12, false);
+WriteAttributeValue("", 7731, severityInt, 7731, 12, false);
 
 #line default
 #line hidden
@@ -446,9 +446,9 @@ WriteAttributeValue("", 7723, severityInt, 7723, 12, false);
 #line hidden
 
             WriteLiteral("                    <option");
-            BeginWriteAttribute("value", " value=\"", 7864, "\"", 7884, 1);
+            BeginWriteAttribute("value", " value=\"", 7872, "\"", 7892, 1);
 #line 230 "DetailsPage.cshtml"
-WriteAttributeValue("", 7872, severityInt, 7872, 12, false);
+WriteAttributeValue("", 7880, severityInt, 7880, 12, false);
 
 #line default
 #line hidden
@@ -468,9 +468,9 @@ WriteAttributeValue("", 7872, severityInt, 7872, 12, false);
 #line hidden
 
             WriteLiteral("        </select>\r\n        <input type=\"text\" name=\"name\"");
-            BeginWriteAttribute("value", " value=\"", 7997, "\"", 8030, 1);
+            BeginWriteAttribute("value", " value=\"", 8005, "\"", 8038, 1);
 #line 234 "DetailsPage.cshtml"
-WriteAttributeValue("", 8005, Model.Options.NamePrefix, 8005, 25, false);
+WriteAttributeValue("", 8013, Model.Options.NamePrefix, 8013, 25, false);
 
 #line default
 #line hidden

--- a/src/Microsoft.AspNetCore.Diagnostics.Elm/Views/DetailsPage.cshtml
+++ b/src/Microsoft.AspNetCore.Diagnostics.Elm/Views/DetailsPage.cshtml
@@ -2,8 +2,8 @@
 @using System.Globalization
 @using System.Linq
 @using Microsoft.AspNetCore.Diagnostics.Elm
-@using Microsoft.AspNetCore.Diagnostics.Views
 @using Microsoft.AspNetCore.Diagnostics.Elm.Views
+@using Microsoft.AspNetCore.DiagnosticsViewPage.Views
 @using Microsoft.Extensions.Logging
 
 @functions

--- a/src/Microsoft.AspNetCore.Diagnostics.Elm/Views/LogPage.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics.Elm/Views/LogPage.cs
@@ -25,19 +25,19 @@ using System.Linq
 #line hidden
     ;
 #line 5 "LogPage.cshtml"
-using Microsoft.AspNetCore.Diagnostics.Elm.Views
-
-#line default
-#line hidden
-    ;
-#line 6 "LogPage.cshtml"
 using Microsoft.AspNetCore.Diagnostics.Elm
 
 #line default
 #line hidden
     ;
+#line 6 "LogPage.cshtml"
+using Microsoft.AspNetCore.Diagnostics.Elm.Views
+
+#line default
+#line hidden
+    ;
 #line 7 "LogPage.cshtml"
-using Microsoft.AspNetCore.Diagnostics.Views
+using Microsoft.AspNetCore.DiagnosticsViewPage.Views
 
 #line default
 #line hidden
@@ -50,7 +50,7 @@ using Microsoft.Extensions.Logging
     ;
     using System.Threading.Tasks;
 
-    public class LogPage : Microsoft.AspNetCore.Diagnostics.Views.BaseView
+    public class LogPage : Microsoft.AspNetCore.DiagnosticsViewPage.Views.BaseView
     {
 #line 11 "LogPage.cshtml"
 
@@ -208,9 +208,9 @@ using Microsoft.Extensions.Logging
 #line hidden
 
             WriteLiteral("                    <option");
-            BeginWriteAttribute("value", " value=\"", 4926, "\"", 4946, 1);
+            BeginWriteAttribute("value", " value=\"", 4934, "\"", 4954, 1);
 #line 138 "LogPage.cshtml"
-WriteAttributeValue("", 4934, severityInt, 4934, 12, false);
+WriteAttributeValue("", 4942, severityInt, 4942, 12, false);
 
 #line default
 #line hidden
@@ -231,9 +231,9 @@ WriteAttributeValue("", 4934, severityInt, 4934, 12, false);
 #line hidden
 
             WriteLiteral("                    <option");
-            BeginWriteAttribute("value", " value=\"", 5075, "\"", 5095, 1);
+            BeginWriteAttribute("value", " value=\"", 5083, "\"", 5103, 1);
 #line 142 "LogPage.cshtml"
-WriteAttributeValue("", 5083, severityInt, 5083, 12, false);
+WriteAttributeValue("", 5091, severityInt, 5091, 12, false);
 
 #line default
 #line hidden
@@ -253,9 +253,9 @@ WriteAttributeValue("", 5083, severityInt, 5083, 12, false);
 #line hidden
 
             WriteLiteral("        </select>\r\n        <input type=\"text\" name=\"name\"");
-            BeginWriteAttribute("value", " value=\"", 5208, "\"", 5241, 1);
+            BeginWriteAttribute("value", " value=\"", 5216, "\"", 5249, 1);
 #line 146 "LogPage.cshtml"
-WriteAttributeValue("", 5216, Model.Options.NamePrefix, 5216, 25, false);
+WriteAttributeValue("", 5224, Model.Options.NamePrefix, 5224, 25, false);
 
 #line default
 #line hidden
@@ -315,16 +315,16 @@ WriteAttributeValue("", 5216, Model.Options.NamePrefix, 5216, 25, false);
 #line hidden
 
             WriteLiteral("                        \t<td><a");
-            BeginWriteAttribute("href", " href=\"", 6305, "\"", 6325, 1);
+            BeginWriteAttribute("href", " href=\"", 6313, "\"", 6333, 1);
 #line 178 "LogPage.cshtml"
-WriteAttributeValue("", 6312, activityPath, 6312, 13, false);
+WriteAttributeValue("", 6320, activityPath, 6320, 13, false);
 
 #line default
 #line hidden
             EndWriteAttribute();
-            BeginWriteAttribute("title", " title=\"", 6326, "\"", 6357, 1);
+            BeginWriteAttribute("title", " title=\"", 6334, "\"", 6365, 1);
 #line 178 "LogPage.cshtml"
-WriteAttributeValue("", 6334, activity.HttpInfo.Path, 6334, 23, false);
+WriteAttributeValue("", 6342, activity.HttpInfo.Path, 6342, 23, false);
 
 #line default
 #line hidden
@@ -363,16 +363,16 @@ WriteAttributeValue("", 6334, activity.HttpInfo.Path, 6334, 23, false);
 #line hidden
 
             WriteLiteral("                            <td colspan=\"4\"><a");
-            BeginWriteAttribute("href", " href=\"", 6747, "\"", 6767, 1);
+            BeginWriteAttribute("href", " href=\"", 6755, "\"", 6775, 1);
 #line 185 "LogPage.cshtml"
-WriteAttributeValue("", 6754, activityPath, 6754, 13, false);
+WriteAttributeValue("", 6762, activityPath, 6762, 13, false);
 
 #line default
 #line hidden
             EndWriteAttribute();
-            BeginWriteAttribute("title", " title=\"", 6768, "\"", 6796, 1);
+            BeginWriteAttribute("title", " title=\"", 6776, "\"", 6804, 1);
 #line 185 "LogPage.cshtml"
-WriteAttributeValue("", 6776, activity.Root.State, 6776, 20, false);
+WriteAttributeValue("", 6784, activity.Root.State, 6784, 20, false);
 
 #line default
 #line hidden
@@ -393,9 +393,9 @@ WriteAttributeValue("", 6776, activity.Root.State, 6776, 20, false);
 #line hidden
 
             WriteLiteral("                            <td colspan=\"4\"><a");
-            BeginWriteAttribute("href", " href=\"", 6959, "\"", 6979, 1);
+            BeginWriteAttribute("href", " href=\"", 6967, "\"", 6987, 1);
 #line 189 "LogPage.cshtml"
-WriteAttributeValue("", 6966, activityPath, 6966, 13, false);
+WriteAttributeValue("", 6974, activityPath, 6974, 13, false);
 
 #line default
 #line hidden

--- a/src/Microsoft.AspNetCore.Diagnostics.Elm/Views/LogPage.cshtml
+++ b/src/Microsoft.AspNetCore.Diagnostics.Elm/Views/LogPage.cshtml
@@ -2,9 +2,9 @@
 @using System.Collections.Generic
 @using System.Globalization
 @using System.Linq
-@using Microsoft.AspNetCore.Diagnostics.Elm.Views
 @using Microsoft.AspNetCore.Diagnostics.Elm
-@using Microsoft.AspNetCore.Diagnostics.Views
+@using Microsoft.AspNetCore.Diagnostics.Elm.Views
+@using Microsoft.AspNetCore.DiagnosticsViewPage.Views
 @using Microsoft.Extensions.Logging
 
 @functions

--- a/src/Microsoft.AspNetCore.Diagnostics.Elm/project.json
+++ b/src/Microsoft.AspNetCore.Diagnostics.Elm/project.json
@@ -19,11 +19,20 @@
     "url": "git://github.com/aspnet/diagnostics"
   },
   "dependencies": {
-    "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",
-    "Microsoft.Extensions.Logging.Abstractions": "1.0.0-*"
+    "Microsoft.AspNetCore.DiagnosticsViewPage.Sources": {
+      "type": "build",
+      "version": "1.0.0-*"
+    },
+    "Microsoft.AspNetCore.Http.Abstractions": "1.0.0-*",
+    "Microsoft.Extensions.Logging.Abstractions": "1.0.0-*",
+    "Microsoft.Extensions.Options": "1.0.0-*"
   },
   "frameworks": {
-    "net451": { },
+    "net451": {
+      "frameworkAssemblies": {
+        "System.IO": ""
+      }
+    },
     "netstandard1.3": {
       "dependencies": {
         "System.Threading": "4.0.11-*"

--- a/src/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore/Views/DatabaseErrorPage.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore/Views/DatabaseErrorPage.cs
@@ -26,7 +26,7 @@ using Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Views
     ;
     using System.Threading.Tasks;
 
-    public class DatabaseErrorPage : Microsoft.AspNetCore.Diagnostics.Views.BaseView
+    public class DatabaseErrorPage : Microsoft.AspNetCore.DiagnosticsViewPage.Views.BaseView
     {
 #line 11 "DatabaseErrorPage.cshtml"
 

--- a/src/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore/project.json
+++ b/src/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore/project.json
@@ -20,16 +20,18 @@
     "xmlDoc": true
   },
   "dependencies": {
-    "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",
+    "Microsoft.AspNetCore.DiagnosticsViewPage.Sources": {
+      "type": "build",
+      "version": "1.0.0-*"
+    },
+    "Microsoft.AspNetCore.Http.Abstractions": "1.0.0-*",
     "Microsoft.EntityFrameworkCore.Relational": "1.0.0-*"
   },
-  "compile": [
-    "..\\Shared\\*.cs"
-  ],
   "frameworks": {
     "net451": {
       "frameworkAssemblies": {
-        "System.Configuration": ""
+        "System.Configuration": "",
+        "System.IO": ""
       }
     },
     "netstandard1.3": {

--- a/src/Microsoft.AspNetCore.Diagnostics/DeveloperExceptionPage/Views/CompilationErrorPage.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics/DeveloperExceptionPage/Views/CompilationErrorPage.cs
@@ -32,7 +32,7 @@ using Microsoft.AspNetCore.Diagnostics
     ;
     using System.Threading.Tasks;
 
-    public class CompilationErrorPage : Microsoft.AspNetCore.Diagnostics.Views.BaseView
+    public class CompilationErrorPage : Microsoft.AspNetCore.DiagnosticsViewPage.Views.BaseView
     {
 #line 7 "CompilationErrorPage.cshtml"
 

--- a/src/Microsoft.AspNetCore.Diagnostics/DeveloperExceptionPage/Views/ErrorPage.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics/DeveloperExceptionPage/Views/ErrorPage.cs
@@ -38,7 +38,7 @@ using Microsoft.AspNetCore.Diagnostics
     ;
     using System.Threading.Tasks;
 
-    public class ErrorPage : Microsoft.AspNetCore.Diagnostics.Views.BaseView
+    public class ErrorPage : Microsoft.AspNetCore.DiagnosticsViewPage.Views.BaseView
     {
 #line 8 "ErrorPage.cshtml"
 

--- a/src/Microsoft.AspNetCore.Diagnostics/RuntimeInfo/Views/RuntimeInfoPage.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics/RuntimeInfo/Views/RuntimeInfoPage.cs
@@ -37,7 +37,7 @@ using Microsoft.Extensions.PlatformAbstractions;
 #line hidden
     using System.Threading.Tasks;
 
-    public class RuntimeInfoPage : Microsoft.AspNetCore.Diagnostics.Views.BaseView
+    public class RuntimeInfoPage : Microsoft.AspNetCore.DiagnosticsViewPage.Views.BaseView
     {
 #line 9 "RuntimeInfoPage.cshtml"
 

--- a/src/Microsoft.AspNetCore.Diagnostics/WelcomePage/Views/WelcomePage.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics/WelcomePage/Views/WelcomePage.cs
@@ -14,7 +14,7 @@ using Microsoft.AspNetCore.Diagnostics
     ;
     using System.Threading.Tasks;
 
-    public class WelcomePage : Microsoft.AspNetCore.Diagnostics.Views.BaseView
+    public class WelcomePage : Microsoft.AspNetCore.DiagnosticsViewPage.Views.BaseView
     {
         #line hidden
         public WelcomePage()

--- a/src/Microsoft.AspNetCore.Diagnostics/project.json
+++ b/src/Microsoft.AspNetCore.Diagnostics/project.json
@@ -20,6 +20,10 @@
   },
   "dependencies": {
     "Microsoft.AspNetCore.Diagnostics.Abstractions": "1.0.0-*",
+    "Microsoft.AspNetCore.DiagnosticsViewPage.Sources": {
+      "type": "build",
+      "version": "1.0.0-*"
+    },
     "Microsoft.AspNetCore.Http.Extensions": "1.0.0-*",
     "Microsoft.AspNetCore.WebUtilities": "1.0.0-*",
     "Microsoft.Extensions.FileProviders.Physical": "1.0.0-*",

--- a/src/Microsoft.AspNetCore.DiagnosticsViewPage.Sources/AttributeValue.cs
+++ b/src/Microsoft.AspNetCore.DiagnosticsViewPage.Sources/AttributeValue.cs
@@ -1,6 +1,9 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 
-namespace Microsoft.AspNetCore.Diagnostics.Views
+namespace Microsoft.AspNetCore.DiagnosticsViewPage.Views
 {
     public class AttributeValue
     {

--- a/src/Microsoft.AspNetCore.DiagnosticsViewPage.Sources/BaseView.cs
+++ b/src/Microsoft.AspNetCore.DiagnosticsViewPage.Sources/BaseView.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -13,7 +12,7 @@ using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
-namespace Microsoft.AspNetCore.Diagnostics.Views
+namespace Microsoft.AspNetCore.DiagnosticsViewPage.Views
 {
     /// <summary>
     /// Infrastructure

--- a/src/Microsoft.AspNetCore.DiagnosticsViewPage.Sources/HelperResult.cs
+++ b/src/Microsoft.AspNetCore.DiagnosticsViewPage.Sources/HelperResult.cs
@@ -4,7 +4,7 @@
 using System;
 using System.IO;
 
-namespace Microsoft.AspNetCore.Diagnostics.Views
+namespace Microsoft.AspNetCore.DiagnosticsViewPage.Views
 {
     /// <summary>
     /// Represents a deferred write operation in a <see cref="BaseView"/>.

--- a/src/Microsoft.AspNetCore.DiagnosticsViewPage.Sources/Microsoft.AspNetCore.DiagnosticsViewPage.Sources.xproj
+++ b/src/Microsoft.AspNetCore.DiagnosticsViewPage.Sources/Microsoft.AspNetCore.DiagnosticsViewPage.Sources.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.24720" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.24720</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>b9f08060-621f-4e1f-bda8-9c4ea107e08a</ProjectGuid>
+    <RootNamespace>Microsoft.AspNetCore.DiagnosticsViewPage.Sources</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/Microsoft.AspNetCore.DiagnosticsViewPage.Sources/project.json
+++ b/src/Microsoft.AspNetCore.DiagnosticsViewPage.Sources/project.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0.0-*",
+  "shared": "*.cs",
+  "dependencies": {},
+  "frameworks": {
+    "netstandard1.0": {}
+  }
+}

--- a/src/PageGenerator/Program.cs
+++ b/src/PageGenerator/Program.cs
@@ -61,7 +61,7 @@ namespace PageGenerator
             var fileNameNoExtension = Path.GetFileNameWithoutExtension(fileName);
             var codeLang = new CSharpRazorCodeLanguage();
             var host = new RazorEngineHost(codeLang);
-            host.DefaultBaseClass = "Microsoft.AspNetCore.Diagnostics.Views.BaseView";
+            host.DefaultBaseClass = "Microsoft.AspNetCore.DiagnosticsViewPage.Views.BaseView";
             host.GeneratedClassContext = new GeneratedClassContext(
                 executeMethodName: GeneratedClassContext.DefaultExecuteMethodName,
                 writeMethodName: GeneratedClassContext.DefaultWriteMethodName,

--- a/test/Microsoft.AspNetCore.Diagnostics.Tests/project.json
+++ b/test/Microsoft.AspNetCore.Diagnostics.Tests/project.json
@@ -4,6 +4,7 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
+    "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",
     "Microsoft.AspNetCore.Diagnostics.Elm": "0.1.0-*",
     "Microsoft.AspNetCore.TestHost": "1.0.0-*",
     "Microsoft.AspNetCore.Testing": "1.0.0-*",


### PR DESCRIPTION
Removed some extraneous dependencies and instead made all the
diagnostics packages be independent packages that happen to share some
concepts/source code.

The common Razor base class code was moved to a shared source file. Then
the Diagnostics page, ELM page, and EF database page all use that. Also
updated the page generator to use the new shared code.

See #257

@rowanmiller @ajcvickers @divega @davidfowl - this is a fix from the meeting earlier today.