### PR TITLE
Add timestamp and duration to Diagnostics Source events

### DIFF
--- a/src/Microsoft.AspNetCore.MiddlewareAnalysis/AnalysisMiddleware.cs
+++ b/src/Microsoft.AspNetCore.MiddlewareAnalysis/AnalysisMiddleware.cs
@@ -28,10 +28,9 @@ namespace Microsoft.AspNetCore.MiddlewareAnalysis
 
         public async Task Invoke(HttpContext httpContext)
         {
-            var startTimestamp = 0L;
+            var startTimestamp = Stopwatch.GetTimestamp();
             if (_diagnostics.IsEnabled("Microsoft.AspNetCore.MiddlewareAnalysis.MiddlewareStarting"))
             {
-                startTimestamp = Stopwatch.GetTimestamp();
                 _diagnostics.Write(
                     "Microsoft.AspNetCore.MiddlewareAnalysis.MiddlewareStarting",
                     new

--- a/src/Microsoft.AspNetCore.MiddlewareAnalysis/AnalysisMiddleware.cs
+++ b/src/Microsoft.AspNetCore.MiddlewareAnalysis/AnalysisMiddleware.cs
@@ -28,9 +28,11 @@ namespace Microsoft.AspNetCore.MiddlewareAnalysis
 
         public async Task Invoke(HttpContext httpContext)
         {
+            var startTimestamp = 0L;
             if (_diagnostics.IsEnabled("Microsoft.AspNetCore.MiddlewareAnalysis.MiddlewareStarting"))
             {
-                _diagnostics.Write("Microsoft.AspNetCore.MiddlewareAnalysis.MiddlewareStarting", new { name = _middlewareName, httpContext = httpContext, instanceId = _instanceId });
+                startTimestamp = Stopwatch.GetTimestamp();
+                _diagnostics.Write("Microsoft.AspNetCore.MiddlewareAnalysis.MiddlewareStarting", new { name = _middlewareName, httpContext = httpContext, instanceId = _instanceId, timestamp = startTimestamp });
             }
 
             try
@@ -39,14 +41,16 @@ namespace Microsoft.AspNetCore.MiddlewareAnalysis
 
                 if (_diagnostics.IsEnabled("Microsoft.AspNetCore.MiddlewareAnalysis.MiddlewareFinished"))
                 {
-                    _diagnostics.Write("Microsoft.AspNetCore.MiddlewareAnalysis.MiddlewareFinished", new { name = _middlewareName, httpContext = httpContext, instanceId = _instanceId });
+                    var currentTimestamp = Stopwatch.GetTimestamp();
+                    _diagnostics.Write("Microsoft.AspNetCore.MiddlewareAnalysis.MiddlewareFinished", new { name = _middlewareName, httpContext = httpContext, instanceId = _instanceId, timestamp = currentTimestamp, duration = currentTimestamp - startTimestamp });
                 }
             }
             catch (Exception ex)
             {
                 if (_diagnostics.IsEnabled("Microsoft.AspNetCore.MiddlewareAnalysis.MiddlewareException"))
                 {
-                    _diagnostics.Write("Microsoft.AspNetCore.MiddlewareAnalysis.MiddlewareException", new { name = _middlewareName, httpContext = httpContext, instanceId = _instanceId, exception = ex });
+                    var currentTimestamp = Stopwatch.GetTimestamp();
+                    _diagnostics.Write("Microsoft.AspNetCore.MiddlewareAnalysis.MiddlewareException", new { name = _middlewareName, httpContext = httpContext, instanceId = _instanceId, timestamp = currentTimestamp, duration = currentTimestamp - startTimestamp, exception = ex });
                 }
                 throw;
             }

--- a/src/Microsoft.AspNetCore.MiddlewareAnalysis/AnalysisMiddleware.cs
+++ b/src/Microsoft.AspNetCore.MiddlewareAnalysis/AnalysisMiddleware.cs
@@ -32,7 +32,15 @@ namespace Microsoft.AspNetCore.MiddlewareAnalysis
             if (_diagnostics.IsEnabled("Microsoft.AspNetCore.MiddlewareAnalysis.MiddlewareStarting"))
             {
                 startTimestamp = Stopwatch.GetTimestamp();
-                _diagnostics.Write("Microsoft.AspNetCore.MiddlewareAnalysis.MiddlewareStarting", new { name = _middlewareName, httpContext = httpContext, instanceId = _instanceId, timestamp = startTimestamp });
+                _diagnostics.Write(
+                    "Microsoft.AspNetCore.MiddlewareAnalysis.MiddlewareStarting",
+                    new
+                    {
+                        name = _middlewareName,
+                        httpContext = httpContext,
+                        instanceId = _instanceId,
+                        timestamp = startTimestamp,
+                    });
             }
 
             try
@@ -42,7 +50,16 @@ namespace Microsoft.AspNetCore.MiddlewareAnalysis
                 if (_diagnostics.IsEnabled("Microsoft.AspNetCore.MiddlewareAnalysis.MiddlewareFinished"))
                 {
                     var currentTimestamp = Stopwatch.GetTimestamp();
-                    _diagnostics.Write("Microsoft.AspNetCore.MiddlewareAnalysis.MiddlewareFinished", new { name = _middlewareName, httpContext = httpContext, instanceId = _instanceId, timestamp = currentTimestamp, duration = currentTimestamp - startTimestamp });
+                    _diagnostics.Write(
+                        "Microsoft.AspNetCore.MiddlewareAnalysis.MiddlewareFinished", 
+                        new
+                        {
+                            name = _middlewareName,
+                            httpContext = httpContext,
+                            instanceId = _instanceId,
+                            timestamp = currentTimestamp,
+                            duration = currentTimestamp - startTimestamp,
+                        });
                 }
             }
             catch (Exception ex)
@@ -50,7 +67,17 @@ namespace Microsoft.AspNetCore.MiddlewareAnalysis
                 if (_diagnostics.IsEnabled("Microsoft.AspNetCore.MiddlewareAnalysis.MiddlewareException"))
                 {
                     var currentTimestamp = Stopwatch.GetTimestamp();
-                    _diagnostics.Write("Microsoft.AspNetCore.MiddlewareAnalysis.MiddlewareException", new { name = _middlewareName, httpContext = httpContext, instanceId = _instanceId, timestamp = currentTimestamp, duration = currentTimestamp - startTimestamp, exception = ex });
+                    _diagnostics.Write(
+                        "Microsoft.AspNetCore.MiddlewareAnalysis.MiddlewareException", 
+                        new
+                        {
+                            name = _middlewareName,
+                            httpContext = httpContext,
+                            instanceId = _instanceId,
+                            timestamp = currentTimestamp,
+                            duration = currentTimestamp - startTimestamp,
+                            exception = ex,
+                        });
                 }
                 throw;
             }


### PR DESCRIPTION
Given the precedence of what we have here https://github.com/aspnet/Hosting/pull/543 I'm adding timestamp data to these events - this ensures that everyone is working from the same base data when talking timings. 

In addition, I'm adding `duration` to the `finish` events so that consumers only have to subscribe to `finish` events in order to determine what the duration for a given piece of middleware is. This change is localized to the scope of code where we know that we have listeners interested in the result and hence isn't on the primary execution path.