### PR TITLE
Include instructions for PMC migrations commands

### DIFF
--- a/src/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore/Properties/Strings.Designer.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore/Properties/Strings.Designer.cs
@@ -77,17 +77,17 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore
         /// <summary>
         /// &gt; dotnet ef migrations add [migration name]
         /// </summary>
-        internal static string DatabaseErrorPage_AddMigrationCommand
+        internal static string DatabaseErrorPage_AddMigrationCommandCLI
         {
-            get { return GetString("DatabaseErrorPage_AddMigrationCommand"); }
+            get { return GetString("DatabaseErrorPage_AddMigrationCommandCLI"); }
         }
 
         /// <summary>
         /// &gt; dotnet ef migrations add [migration name]
         /// </summary>
-        internal static string FormatDatabaseErrorPage_AddMigrationCommand()
+        internal static string FormatDatabaseErrorPage_AddMigrationCommandCLI()
         {
-            return GetString("DatabaseErrorPage_AddMigrationCommand");
+            return GetString("DatabaseErrorPage_AddMigrationCommandCLI");
         }
 
         /// <summary>
@@ -155,19 +155,19 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore
         }
 
         /// <summary>
-        /// You can also apply migrations from the command line:
+        /// In Visual Studio, you can use Package Manager Console apply pending migrations to the database:
         /// </summary>
-        internal static string DatabaseErrorPage_HowToApplyFromCmd
+        internal static string DatabaseErrorPage_HowToApplyFromPMC
         {
-            get { return GetString("DatabaseErrorPage_HowToApplyFromCmd"); }
+            get { return GetString("DatabaseErrorPage_HowToApplyFromPMC"); }
         }
 
         /// <summary>
-        /// You can also apply migrations from the command line:
+        /// In Visual Studio, you can use Package Manager Console apply pending migrations to the database:
         /// </summary>
-        internal static string FormatDatabaseErrorPage_HowToApplyFromCmd()
+        internal static string FormatDatabaseErrorPage_HowToApplyFromPMC()
         {
-            return GetString("DatabaseErrorPage_HowToApplyFromCmd");
+            return GetString("DatabaseErrorPage_HowToApplyFromPMC");
         }
 
         /// <summary>
@@ -187,19 +187,19 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore
         }
 
         /// <summary>
-        /// From the command line, scaffold a new migration and apply it to the database:
+        /// In Visual Studio, use Package Manager Console to scaffold a new migration and apply it to the database:
         /// </summary>
-        internal static string DatabaseErrorPage_NoDbOrMigrationsInfo
+        internal static string DatabaseErrorPage_NoDbOrMigrationsInfoPMC
         {
-            get { return GetString("DatabaseErrorPage_NoDbOrMigrationsInfo"); }
+            get { return GetString("DatabaseErrorPage_NoDbOrMigrationsInfoPMC"); }
         }
 
         /// <summary>
-        /// From the command line, scaffold a new migration and apply it to the database:
+        /// In Visual Studio, use Package Manager Console to scaffold a new migration and apply it to the database:
         /// </summary>
-        internal static string FormatDatabaseErrorPage_NoDbOrMigrationsInfo()
+        internal static string FormatDatabaseErrorPage_NoDbOrMigrationsInfoPMC()
         {
-            return GetString("DatabaseErrorPage_NoDbOrMigrationsInfo");
+            return GetString("DatabaseErrorPage_NoDbOrMigrationsInfoPMC");
         }
 
         /// <summary>
@@ -219,19 +219,19 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore
         }
 
         /// <summary>
-        /// Scaffold a new migration for these changes and apply them to the database from the command line:
+        /// In Visual Studio, use Package Manager Console to scaffold a new migration for these changes and apply them to the database:
         /// </summary>
-        internal static string DatabaseErrorPage_PendingChangesInfo
+        internal static string DatabaseErrorPage_PendingChangesInfoPMC
         {
-            get { return GetString("DatabaseErrorPage_PendingChangesInfo"); }
+            get { return GetString("DatabaseErrorPage_PendingChangesInfoPMC"); }
         }
 
         /// <summary>
-        /// Scaffold a new migration for these changes and apply them to the database from the command line:
+        /// In Visual Studio, use Package Manager Console to scaffold a new migration for these changes and apply them to the database:
         /// </summary>
-        internal static string FormatDatabaseErrorPage_PendingChangesInfo()
+        internal static string FormatDatabaseErrorPage_PendingChangesInfoPMC()
         {
-            return GetString("DatabaseErrorPage_PendingChangesInfo");
+            return GetString("DatabaseErrorPage_PendingChangesInfoPMC");
         }
 
         /// <summary>
@@ -285,17 +285,17 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore
         /// <summary>
         /// &gt; dotnet ef database update
         /// </summary>
-        internal static string DatabaseErrorPage_ApplyMigrationsCommand
+        internal static string DatabaseErrorPage_ApplyMigrationsCommandCLI
         {
-            get { return GetString("DatabaseErrorPage_ApplyMigrationsCommand"); }
+            get { return GetString("DatabaseErrorPage_ApplyMigrationsCommandCLI"); }
         }
 
         /// <summary>
         /// &gt; dotnet ef database update
         /// </summary>
-        internal static string FormatDatabaseErrorPage_ApplyMigrationsCommand()
+        internal static string FormatDatabaseErrorPage_ApplyMigrationsCommandCLI()
         {
-            return GetString("DatabaseErrorPage_ApplyMigrationsCommand");
+            return GetString("DatabaseErrorPage_ApplyMigrationsCommandCLI");
         }
 
         /// <summary>
@@ -520,6 +520,86 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore
         internal static string FormatDatabaseErrorPage_NoMatch()
         {
             return GetString("DatabaseErrorPage_NoMatch");
+        }
+
+        /// <summary>
+        /// PM&gt; Add-Migration [migration name]
+        /// </summary>
+        internal static string DatabaseErrorPage_AddMigrationCommandPMC
+        {
+            get { return GetString("DatabaseErrorPage_AddMigrationCommandPMC"); }
+        }
+
+        /// <summary>
+        /// PM&gt; Add-Migration [migration name]
+        /// </summary>
+        internal static string FormatDatabaseErrorPage_AddMigrationCommandPMC()
+        {
+            return GetString("DatabaseErrorPage_AddMigrationCommandPMC");
+        }
+
+        /// <summary>
+        /// PM&gt; Update-Database
+        /// </summary>
+        internal static string DatabaseErrorPage_ApplyMigrationsCommandPMC
+        {
+            get { return GetString("DatabaseErrorPage_ApplyMigrationsCommandPMC"); }
+        }
+
+        /// <summary>
+        /// PM&gt; Update-Database
+        /// </summary>
+        internal static string FormatDatabaseErrorPage_ApplyMigrationsCommandPMC()
+        {
+            return GetString("DatabaseErrorPage_ApplyMigrationsCommandPMC");
+        }
+
+        /// <summary>
+        /// Alternatively, you can scaffold a new migration and apply it from a command prompt at your project directory:
+        /// </summary>
+        internal static string DatabaseErrorPage_NoDbOrMigrationsInfoCLI
+        {
+            get { return GetString("DatabaseErrorPage_NoDbOrMigrationsInfoCLI"); }
+        }
+
+        /// <summary>
+        /// Alternatively, you can scaffold a new migration and apply it from a command prompt at your project directory:
+        /// </summary>
+        internal static string FormatDatabaseErrorPage_NoDbOrMigrationsInfoCLI()
+        {
+            return GetString("DatabaseErrorPage_NoDbOrMigrationsInfoCLI");
+        }
+
+        /// <summary>
+        /// Alternatively, you can scaffold a new migration and apply it from a command prompt at your project directory:
+        /// </summary>
+        internal static string DatabaseErrorPage_PendingChangesInfoCLI
+        {
+            get { return GetString("DatabaseErrorPage_PendingChangesInfoCLI"); }
+        }
+
+        /// <summary>
+        /// Alternatively, you can scaffold a new migration and apply it from a command prompt at your project directory:
+        /// </summary>
+        internal static string FormatDatabaseErrorPage_PendingChangesInfoCLI()
+        {
+            return GetString("DatabaseErrorPage_PendingChangesInfoCLI");
+        }
+
+        /// <summary>
+        /// Alternatively, you can apply pending migrations from a command prompt at your project directory:
+        /// </summary>
+        internal static string DatabaseErrorPage_HowToApplyFromCLI
+        {
+            get { return GetString("DatabaseErrorPage_HowToApplyFromCLI"); }
+        }
+
+        /// <summary>
+        /// Alternatively, you can apply pending migrations from a command prompt at your project directory:
+        /// </summary>
+        internal static string FormatDatabaseErrorPage_HowToApplyFromCLI()
+        {
+            return GetString("DatabaseErrorPage_HowToApplyFromCLI");
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore/Strings.resx
+++ b/src/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore/Strings.resx
@@ -129,7 +129,7 @@
   <data name="DatabaseErrorPageMiddleware_Exception" xml:space="preserve">
     <value>An exception occurred while calculating the database error page content. Skipping display of the database error page.</value>
   </data>
-  <data name="DatabaseErrorPage_AddMigrationCommand" xml:space="preserve">
+  <data name="DatabaseErrorPage_AddMigrationCommandCLI" xml:space="preserve">
     <value>&gt; dotnet ef migrations add [migration name]</value>
   </data>
   <data name="DatabaseErrorPage_ApplyMigrationsButton" xml:space="preserve">
@@ -144,20 +144,20 @@
   <data name="DatabaseErrorPage_ApplyMigrationsFailed" xml:space="preserve">
     <value>An error occurred applying migrations, try applying them from the command line</value>
   </data>
-  <data name="DatabaseErrorPage_HowToApplyFromCmd" xml:space="preserve">
-    <value>You can also apply migrations from the command line:</value>
+  <data name="DatabaseErrorPage_HowToApplyFromPMC" xml:space="preserve">
+    <value>In Visual Studio, you can use the Package Manager Console to apply pending migrations to the database:</value>
   </data>
   <data name="DatabaseErrorPage_MigrationsAppliedRefresh" xml:space="preserve">
     <value>Try refreshing the page</value>
   </data>
-  <data name="DatabaseErrorPage_NoDbOrMigrationsInfo" xml:space="preserve">
-    <value>From the command line, scaffold a new migration and apply it to the database:</value>
+  <data name="DatabaseErrorPage_NoDbOrMigrationsInfoPMC" xml:space="preserve">
+    <value>In Visual Studio, use the Package Manager Console to scaffold a new migration and apply it to the database:</value>
   </data>
   <data name="DatabaseErrorPage_NoDbOrMigrationsTitle" xml:space="preserve">
     <value>Use migrations to create the database for {0}</value>
   </data>
-  <data name="DatabaseErrorPage_PendingChangesInfo" xml:space="preserve">
-    <value>Scaffold a new migration for these changes and apply them to the database from the command line:</value>
+  <data name="DatabaseErrorPage_PendingChangesInfoPMC" xml:space="preserve">
+    <value>In Visual Studio, use the Package Manager Console to scaffold a new migration for these changes and apply them to the database:</value>
   </data>
   <data name="DatabaseErrorPage_PendingChangesTitle" xml:space="preserve">
     <value>There are pending model changes for {0}</value>
@@ -168,7 +168,7 @@
   <data name="DatabaseErrorPage_PendingMigrationsTitle" xml:space="preserve">
     <value>Applying existing migrations for {0} may resolve this issue</value>
   </data>
-  <data name="DatabaseErrorPage_ApplyMigrationsCommand" xml:space="preserve">
+  <data name="DatabaseErrorPage_ApplyMigrationsCommandCLI" xml:space="preserve">
     <value>&gt; dotnet ef database update</value>
   </data>
   <data name="InvalidEnumValue" xml:space="preserve">
@@ -212,5 +212,20 @@
   </data>
   <data name="DatabaseErrorPage_NoMatch" xml:space="preserve">
     <value>The current exception (and its inner exceptions) do not match the last exception Entity Framework recorded due to a failed database operation. This means the database operation exception was handled and another exception occurred later in the request.</value>
+  </data>
+  <data name="DatabaseErrorPage_AddMigrationCommandPMC" xml:space="preserve">
+    <value>PM&gt; Add-Migration [migration name]</value>
+  </data>
+  <data name="DatabaseErrorPage_ApplyMigrationsCommandPMC" xml:space="preserve">
+    <value>PM&gt; Update-Database</value>
+  </data>
+  <data name="DatabaseErrorPage_NoDbOrMigrationsInfoCLI" xml:space="preserve">
+    <value>Alternatively, you can scaffold a new migration and apply it from a command prompt at your project directory:</value>
+  </data>
+  <data name="DatabaseErrorPage_PendingChangesInfoCLI" xml:space="preserve">
+    <value>Alternatively, you can scaffold a new migration and apply it from a command prompt at your project directory:</value>
+  </data>
+  <data name="DatabaseErrorPage_HowToApplyFromCLI" xml:space="preserve">
+    <value>Alternatively, you can apply pending migrations from a command prompt at your project directory:</value>
   </data>
 </root>

--- a/src/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore/Views/DatabaseErrorPage.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore/Views/DatabaseErrorPage.cs
@@ -122,24 +122,42 @@ using Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Views
 #line hidden
             WriteLiteral("</h2>\r\n        <p>");
 #line 48 "DatabaseErrorPage.cshtml"
-      Write(Strings.DatabaseErrorPage_NoDbOrMigrationsInfo);
+      Write(Strings.DatabaseErrorPage_NoDbOrMigrationsInfoPMC);
 
 #line default
 #line hidden
             WriteLiteral("</p>\r\n        <code> ");
 #line 49 "DatabaseErrorPage.cshtml"
-          Write(Strings.DatabaseErrorPage_AddMigrationCommand);
+          Write(Strings.DatabaseErrorPage_AddMigrationCommandPMC);
 
 #line default
 #line hidden
-            WriteLiteral(" </code>\r\n        <br />\r\n        <code> ");
+            WriteLiteral("</code>\r\n        <br />\r\n        <code> ");
 #line 51 "DatabaseErrorPage.cshtml"
-          Write(Strings.DatabaseErrorPage_ApplyMigrationsCommand);
+          Write(Strings.DatabaseErrorPage_ApplyMigrationsCommandPMC);
 
 #line default
 #line hidden
-            WriteLiteral(" </code>\r\n        <hr />\r\n");
+            WriteLiteral("</code>\r\n        <p>");
+#line 52 "DatabaseErrorPage.cshtml"
+      Write(Strings.DatabaseErrorPage_NoDbOrMigrationsInfoCLI);
+
+#line default
+#line hidden
+            WriteLiteral("</p>\r\n        <code> ");
 #line 53 "DatabaseErrorPage.cshtml"
+          Write(Strings.DatabaseErrorPage_AddMigrationCommandCLI);
+
+#line default
+#line hidden
+            WriteLiteral("</code>\r\n        <br />\r\n        <code> ");
+#line 55 "DatabaseErrorPage.cshtml"
+          Write(Strings.DatabaseErrorPage_ApplyMigrationsCommandCLI);
+
+#line default
+#line hidden
+            WriteLiteral("</code>\r\n        <hr />\r\n");
+#line 57 "DatabaseErrorPage.cshtml"
     }
     else if (Model.PendingMigrations.Any())
     {
@@ -148,25 +166,25 @@ using Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Views
 #line hidden
 
             WriteLiteral("        <div>\r\n            <h2>");
-#line 57 "DatabaseErrorPage.cshtml"
+#line 61 "DatabaseErrorPage.cshtml"
            Write(Strings.FormatDatabaseErrorPage_PendingMigrationsTitle(Model.ContextType.Name));
 
 #line default
 #line hidden
             WriteLiteral("</h2>\r\n            <p>");
-#line 58 "DatabaseErrorPage.cshtml"
+#line 62 "DatabaseErrorPage.cshtml"
           Write(Strings.FormatDatabaseErrorPage_PendingMigrationsInfo(Model.ContextType.Name));
 
 #line default
 #line hidden
             WriteLiteral("</p>\r\n\r\n            <ul>\r\n");
-#line 61 "DatabaseErrorPage.cshtml"
+#line 65 "DatabaseErrorPage.cshtml"
                 
 
 #line default
 #line hidden
 
-#line 61 "DatabaseErrorPage.cshtml"
+#line 65 "DatabaseErrorPage.cshtml"
                  foreach (var migration in Model.PendingMigrations)
                 {
 
@@ -174,20 +192,20 @@ using Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Views
 #line hidden
 
             WriteLiteral("                    <li>");
-#line 63 "DatabaseErrorPage.cshtml"
+#line 67 "DatabaseErrorPage.cshtml"
                    Write(migration);
 
 #line default
 #line hidden
             WriteLiteral("</li>\r\n");
-#line 64 "DatabaseErrorPage.cshtml"
+#line 68 "DatabaseErrorPage.cshtml"
                 }
 
 #line default
 #line hidden
 
             WriteLiteral("            </ul>\r\n\r\n            <p>\r\n                <button id=\"applyMigrations\" onclick=\"ApplyMigrations()\">");
-#line 68 "DatabaseErrorPage.cshtml"
+#line 72 "DatabaseErrorPage.cshtml"
                                                                     Write(Strings.DatabaseErrorPage_ApplyMigrationsButton);
 
 #line default
@@ -201,19 +219,19 @@ using Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Views
                     applyMigrations.disabled = true;
                     applyMigrationsError.innerHTML = """";
                     applyMigrations.innerHTML = """);
-#line 76 "DatabaseErrorPage.cshtml"
+#line 80 "DatabaseErrorPage.cshtml"
                                             Write(JavaScriptEncode(Strings.DatabaseErrorPage_ApplyMigrationsButtonRunning));
 
 #line default
 #line hidden
             WriteLiteral("\";\r\n\r\n                    var req = new XMLHttpRequest();\r\n\r\n                    req.onload = function (e) {\r\n                        if (req.status === 204) {\r\n                            applyMigrations.innerHTML = \"");
-#line 82 "DatabaseErrorPage.cshtml"
+#line 86 "DatabaseErrorPage.cshtml"
                                                     Write(JavaScriptEncode(Strings.DatabaseErrorPage_ApplyMigrationsButtonDone));
 
 #line default
 #line hidden
             WriteLiteral("\";\r\n                            applyMigrationsSuccess.innerHTML = \"");
-#line 83 "DatabaseErrorPage.cshtml"
+#line 87 "DatabaseErrorPage.cshtml"
                                                            Write(JavaScriptEncode(Strings.DatabaseErrorPage_MigrationsAppliedRefresh));
 
 #line default
@@ -229,13 +247,13 @@ using Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Views
                     };
 
                     var formBody = ""context=");
-#line 93 "DatabaseErrorPage.cshtml"
+#line 97 "DatabaseErrorPage.cshtml"
                                        Write(JavaScriptEncode(UrlEncode(Model.ContextType.AssemblyQualifiedName)));
 
 #line default
 #line hidden
             WriteLiteral("\";\r\n                    req.open(\"POST\", \"");
-#line 94 "DatabaseErrorPage.cshtml"
+#line 98 "DatabaseErrorPage.cshtml"
                                  Write(JavaScriptEncode(Model.Options.MigrationsEndPointPath.Value));
 
 #line default
@@ -249,31 +267,43 @@ using Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Views
 
                 function ErrorApplyingMigrations() {
                     applyMigrations.innerHTML = """);
-#line 102 "DatabaseErrorPage.cshtml"
+#line 106 "DatabaseErrorPage.cshtml"
                                             Write(JavaScriptEncode(Strings.DatabaseErrorPage_ApplyMigrationsButton));
 
 #line default
 #line hidden
             WriteLiteral("\";\r\n                    applyMigrationsError.innerHTML = \"");
-#line 103 "DatabaseErrorPage.cshtml"
+#line 107 "DatabaseErrorPage.cshtml"
                                                  Write(JavaScriptEncode(Strings.DatabaseErrorPage_ApplyMigrationsFailed));
 
 #line default
 #line hidden
             WriteLiteral("\";\r\n                    applyMigrations.disabled = false;\r\n                }\r\n            </script>\r\n\r\n            <p>");
-#line 108 "DatabaseErrorPage.cshtml"
-          Write(Strings.DatabaseErrorPage_HowToApplyFromCmd);
+#line 112 "DatabaseErrorPage.cshtml"
+          Write(Strings.DatabaseErrorPage_HowToApplyFromPMC);
 
 #line default
 #line hidden
             WriteLiteral("</p>\r\n            <code>");
-#line 109 "DatabaseErrorPage.cshtml"
-             Write(Strings.DatabaseErrorPage_ApplyMigrationsCommand);
+#line 113 "DatabaseErrorPage.cshtml"
+             Write(Strings.DatabaseErrorPage_ApplyMigrationsCommandPMC);
+
+#line default
+#line hidden
+            WriteLiteral("</code>\r\n            <p>");
+#line 114 "DatabaseErrorPage.cshtml"
+          Write(Strings.DatabaseErrorPage_HowToApplyFromCLI);
+
+#line default
+#line hidden
+            WriteLiteral("</p>\r\n            <code>");
+#line 115 "DatabaseErrorPage.cshtml"
+             Write(Strings.DatabaseErrorPage_ApplyMigrationsCommandCLI);
 
 #line default
 #line hidden
             WriteLiteral("</code>\r\n            <hr />\r\n        </div>\r\n");
-#line 112 "DatabaseErrorPage.cshtml"
+#line 118 "DatabaseErrorPage.cshtml"
     }
     else if (Model.PendingModelChanges)
     {
@@ -282,31 +312,49 @@ using Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Views
 #line hidden
 
             WriteLiteral("        <div>\r\n            <h2>");
-#line 116 "DatabaseErrorPage.cshtml"
+#line 122 "DatabaseErrorPage.cshtml"
            Write(Strings.FormatDatabaseErrorPage_PendingChangesTitle(Model.ContextType.Name));
 
 #line default
 #line hidden
             WriteLiteral("</h2>\r\n            <p>");
-#line 117 "DatabaseErrorPage.cshtml"
-          Write(Strings.DatabaseErrorPage_PendingChangesInfo);
+#line 123 "DatabaseErrorPage.cshtml"
+          Write(Strings.DatabaseErrorPage_PendingChangesInfoPMC);
 
 #line default
 #line hidden
             WriteLiteral("</p>\r\n            <code>");
-#line 118 "DatabaseErrorPage.cshtml"
-             Write(Strings.DatabaseErrorPage_AddMigrationCommand);
+#line 124 "DatabaseErrorPage.cshtml"
+             Write(Strings.DatabaseErrorPage_AddMigrationCommandPMC);
 
 #line default
 #line hidden
             WriteLiteral("</code>\r\n            <br />\r\n            <code>");
-#line 120 "DatabaseErrorPage.cshtml"
-             Write(Strings.DatabaseErrorPage_ApplyMigrationsCommand);
+#line 126 "DatabaseErrorPage.cshtml"
+             Write(Strings.DatabaseErrorPage_ApplyMigrationsCommandPMC);
+
+#line default
+#line hidden
+            WriteLiteral("</code>\r\n            <p>");
+#line 127 "DatabaseErrorPage.cshtml"
+          Write(Strings.DatabaseErrorPage_PendingChangesInfoCLI);
+
+#line default
+#line hidden
+            WriteLiteral("</p>\r\n            <code>");
+#line 128 "DatabaseErrorPage.cshtml"
+             Write(Strings.DatabaseErrorPage_AddMigrationCommandCLI);
+
+#line default
+#line hidden
+            WriteLiteral("</code>\r\n            <br />\r\n            <code>");
+#line 130 "DatabaseErrorPage.cshtml"
+             Write(Strings.DatabaseErrorPage_ApplyMigrationsCommandCLI);
 
 #line default
 #line hidden
             WriteLiteral("</code>\r\n            <hr />\r\n        </div>\r\n");
-#line 123 "DatabaseErrorPage.cshtml"
+#line 133 "DatabaseErrorPage.cshtml"
     }
 
 #line default

--- a/src/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore/Views/DatabaseErrorPage.cshtml
+++ b/src/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore/Views/DatabaseErrorPage.cshtml
@@ -1,4 +1,4 @@
-@using System
+﻿@using System
 @using System.Linq
 @using Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore
 @using Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Views
@@ -45,10 +45,14 @@
     @if (!Model.DatabaseExists && !Model.PendingMigrations.Any())
     {
         <h2>@Strings.FormatDatabaseErrorPage_NoDbOrMigrationsTitle(Model.ContextType.Name)</h2>
-        <p>@Strings.DatabaseErrorPage_NoDbOrMigrationsInfo</p>
-        <code> @Strings.DatabaseErrorPage_AddMigrationCommand </code>
+        <p>@Strings.DatabaseErrorPage_NoDbOrMigrationsInfoPMC</p>
+        <code> @Strings.DatabaseErrorPage_AddMigrationCommandPMC</code>
         <br />
-        <code> @Strings.DatabaseErrorPage_ApplyMigrationsCommand </code>
+        <code> @Strings.DatabaseErrorPage_ApplyMigrationsCommandPMC</code>
+        <p>@Strings.DatabaseErrorPage_NoDbOrMigrationsInfoCLI</p>
+        <code> @Strings.DatabaseErrorPage_AddMigrationCommandCLI</code>
+        <br />
+        <code> @Strings.DatabaseErrorPage_ApplyMigrationsCommandCLI</code>
         <hr />
     }
     else if (Model.PendingMigrations.Any())
@@ -105,8 +109,10 @@
                 }
             </script>
 
-            <p>@Strings.DatabaseErrorPage_HowToApplyFromCmd</p>
-            <code>@Strings.DatabaseErrorPage_ApplyMigrationsCommand</code>
+            <p>@Strings.DatabaseErrorPage_HowToApplyFromPMC</p>
+            <code>@Strings.DatabaseErrorPage_ApplyMigrationsCommandPMC</code>
+            <p>@Strings.DatabaseErrorPage_HowToApplyFromCLI</p>
+            <code>@Strings.DatabaseErrorPage_ApplyMigrationsCommandCLI</code>
             <hr />
         </div>
     }
@@ -114,10 +120,14 @@
     {
         <div>
             <h2>@Strings.FormatDatabaseErrorPage_PendingChangesTitle(Model.ContextType.Name)</h2>
-            <p>@Strings.DatabaseErrorPage_PendingChangesInfo</p>
-            <code>@Strings.DatabaseErrorPage_AddMigrationCommand</code>
+            <p>@Strings.DatabaseErrorPage_PendingChangesInfoPMC</p>
+            <code>@Strings.DatabaseErrorPage_AddMigrationCommandPMC</code>
             <br />
-            <code>@Strings.DatabaseErrorPage_ApplyMigrationsCommand</code>
+            <code>@Strings.DatabaseErrorPage_ApplyMigrationsCommandPMC</code>
+            <p>@Strings.DatabaseErrorPage_PendingChangesInfoCLI</p>
+            <code>@Strings.DatabaseErrorPage_AddMigrationCommandCLI</code>
+            <br />
+            <code>@Strings.DatabaseErrorPage_ApplyMigrationsCommandCLI</code>
             <hr />
         </div>
     }

--- a/src/PageGenerator/Program.cs
+++ b/src/PageGenerator/Program.cs
@@ -14,7 +14,7 @@ namespace PageGenerator
     {
         private const int NumArgs = 1;
 
-        public void Main(string[] args)
+        public static void Main(string[] args)
         {
             if (args.Length != NumArgs)
             {

--- a/src/PageGenerator/project.json
+++ b/src/PageGenerator/project.json
@@ -2,6 +2,7 @@
   "version": "1.0.0-*",
   "description": "Builds the pages for the Diagnostics projects. Runs in build.cmd.",
   "buildOptions": {
+    "emitEntryPoint": true,
     "warningsAsErrors": true,
     "keyFile": "../../tools/Key.snk"
   },

--- a/test/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.FunctionalTests/DatabaseErrorPageMiddlewareTest.cs
+++ b/test/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.FunctionalTests/DatabaseErrorPageMiddlewareTest.cs
@@ -115,8 +115,8 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
             Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
             var content = await response.Content.ReadAsStringAsync();
             Assert.Contains(StringsHelpers.GetResourceString("FormatDatabaseErrorPage_NoDbOrMigrationsTitle", typeof(BloggingContext).Name), content);
-            Assert.Contains(StringsHelpers.GetResourceString("FormatDatabaseErrorPage_AddMigrationCommand").Replace(">", "&gt;"), content);
-            Assert.Contains(StringsHelpers.GetResourceString("FormatDatabaseErrorPage_ApplyMigrationsCommand").Replace(">", "&gt;"), content);
+            Assert.Contains(StringsHelpers.GetResourceString("FormatDatabaseErrorPage_AddMigrationCommandPMC").Replace(">", "&gt;"), content);
+            Assert.Contains(StringsHelpers.GetResourceString("FormatDatabaseErrorPage_ApplyMigrationsCommandPMC").Replace(">", "&gt;"), content);
         }
 
         class NoMigrationsMiddleware
@@ -144,11 +144,11 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
 
             var content = await response.Content.ReadAsStringAsync();
             Assert.Contains(StringsHelpers.GetResourceString("FormatDatabaseErrorPage_PendingMigrationsTitle", typeof(BloggingContextWithMigrations).Name), content);
-            Assert.Contains(StringsHelpers.GetResourceString("FormatDatabaseErrorPage_ApplyMigrationsCommand").Replace(">", "&gt;"), content);
+            Assert.Contains(StringsHelpers.GetResourceString("FormatDatabaseErrorPage_ApplyMigrationsCommandPMC").Replace(">", "&gt;"), content);
             Assert.Contains("<li>111111111111111_MigrationOne</li>", content);
             Assert.Contains("<li>222222222222222_MigrationTwo</li>", content);
 
-            Assert.DoesNotContain(StringsHelpers.GetResourceString("FormatDatabaseErrorPage_AddMigrationCommand").Replace(">", "&gt;"), content);
+            Assert.DoesNotContain(StringsHelpers.GetResourceString("FormatDatabaseErrorPage_AddMigrationCommandPMC").Replace(">", "&gt;"), content);
         }
 
         class PendingMigrationsMiddleware

--- a/test/Microsoft.AspNetCore.Diagnostics.FunctionalTests/DatabaseErrorPageSampleTest.cs
+++ b/test/Microsoft.AspNetCore.Diagnostics.FunctionalTests/DatabaseErrorPageSampleTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Diagnostics.FunctionalTests
             // Assert
             var body = await response.Content.ReadAsStringAsync();
             Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
-            Assert.Contains("From the command line, scaffold a new migration and apply it to the database:", body);
+            Assert.Contains("In Visual Studio, use the Package Manager Console to scaffold a new migration and apply it to the database:", body);
         }
     }
 }


### PR DESCRIPTION
Update database error page to include instructions for using Package Manager Console commands to add/apply migrations.