### PR TITLE
Improvement to Status Code Page

### DIFF
--- a/src/Microsoft.AspNetCore.Diagnostics/StatusCodePage/StatusCodePagesOptions.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics/StatusCodePage/StatusCodePagesOptions.cs
@@ -20,7 +20,6 @@ namespace Microsoft.AspNetCore.Builder
             HandleAsync = context =>
             {
                 // TODO: Render with a pre-compiled html razor view.
-                // Note the 500 spaces are to work around an IE 'feature'
                 var statusCode = context.HttpContext.Response.StatusCode;
 
                 var body = BuildResponseBody(statusCode);
@@ -32,17 +31,16 @@ namespace Microsoft.AspNetCore.Builder
 
         private string BuildResponseBody(int httpStatusCode)
         {
+            // Note the 500 spaces are to work around an IE 'feature'
             string internetExplorerWorkaround = new string(' ', 500);
+
             var reasonPhrase = ReasonPhrases.GetReasonPhrase(httpStatusCode);
 
-            if (string.IsNullOrWhiteSpace(reasonPhrase))
-            {
-                return string.Format(CultureInfo.InvariantCulture, "Status Code: {0} {1}", httpStatusCode, internetExplorerWorkaround);
-            }
-            else
-            {
-                return string.Format(CultureInfo.InvariantCulture, "Status Code: {0}; {1}{2}", httpStatusCode, reasonPhrase, internetExplorerWorkaround);
-            }
+            return string.Format(CultureInfo.InvariantCulture, "Status Code: {0}{1}{2}{3}",
+                                                                    httpStatusCode,
+                                                                    string.IsNullOrWhiteSpace(reasonPhrase) ? "" : "; ",
+                                                                    reasonPhrase,
+                                                                    internetExplorerWorkaround);
         }
 
         public Func<StatusCodeContext, Task> HandleAsync { get; set; }

--- a/src/Microsoft.AspNetCore.Diagnostics/StatusCodePage/StatusCodePagesOptions.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics/StatusCodePage/StatusCodePagesOptions.cs
@@ -22,11 +22,27 @@ namespace Microsoft.AspNetCore.Builder
                 // TODO: Render with a pre-compiled html razor view.
                 // Note the 500 spaces are to work around an IE 'feature'
                 var statusCode = context.HttpContext.Response.StatusCode;
-                var body = string.Format(CultureInfo.InvariantCulture, "Status Code: {0}; {1}",
-                    statusCode, ReasonPhrases.GetReasonPhrase(statusCode)) + new string(' ', 500);
+
+                var body = BuildResponseBody(statusCode);
+
                 context.HttpContext.Response.ContentType = "text/plain";
                 return context.HttpContext.Response.WriteAsync(body);
             };
+        }
+
+        private string BuildResponseBody(int httpStatusCode)
+        {
+            string internetExplorerWorkaround = new string(' ', 500);
+            var reasonPhrase = ReasonPhrases.GetReasonPhrase(httpStatusCode);
+
+            if (string.IsNullOrWhiteSpace(reasonPhrase))
+            {
+                return string.Format(CultureInfo.InvariantCulture, "Status Code: {0} {1}", httpStatusCode, internetExplorerWorkaround);
+            }
+            else
+            {
+                return string.Format(CultureInfo.InvariantCulture, "Status Code: {0}; {1}{2}", httpStatusCode, reasonPhrase, internetExplorerWorkaround);
+            }
         }
 
         public Func<StatusCodeContext, Task> HandleAsync { get; set; }

--- a/test/Microsoft.AspNetCore.Diagnostics.FunctionalTests/StatusCodeSampleTest.cs
+++ b/test/Microsoft.AspNetCore.Diagnostics.FunctionalTests/StatusCodeSampleTest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Diagnostics.FunctionalTests
         }
 
         [Fact]
-        public async Task StatusCodePageOptions_ExcludesSemicolon_AndReasonPhrase_WhenReasonPhrase_IsUnknown()
+        public async Task StatusCodePageOptions_ExcludesSemicolon_WhenReasonPhrase_IsUnknown()
         {
             //Arrange
             var httpStatusCode = 541;
@@ -44,7 +44,6 @@ namespace Microsoft.AspNetCore.Diagnostics.FunctionalTests
             var response = await Client.SendAsync(request);
 
             var statusCode = response.StatusCode;
-            var statusCodeReasonPhrase = ReasonPhrases.GetReasonPhrase(httpStatusCode);
 
             var responseBody = await response.Content.ReadAsStringAsync();
 

--- a/test/Microsoft.AspNetCore.Diagnostics.FunctionalTests/StatusCodeSampleTest.cs
+++ b/test/Microsoft.AspNetCore.Diagnostics.FunctionalTests/StatusCodeSampleTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.AspNetCore.WebUtilities;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -30,6 +31,44 @@ namespace Microsoft.AspNetCore.Diagnostics.FunctionalTests
             var body = await response.Content.ReadAsStringAsync();
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Contains("Status Code: 417", body);
+        }
+
+        [Fact]
+        public async Task StatusCodePageOptions_HidesSemicolon_WhenReasonPhrase_IsUnknown()
+        {
+            var httpStatusCode = 400;
+
+            do
+            {
+                //Arrange    
+                var request = new HttpRequestMessage(HttpMethod.Get, $"http://localhost/?statuscode={httpStatusCode}");
+
+                //Act
+                var response = await Client.SendAsync(request);
+
+                var statusCode = response.StatusCode;
+                var statusCodeReasonPhrase = ReasonPhrases.GetReasonPhrase(httpStatusCode);
+
+                var responseBody = await response.Content.ReadAsStringAsync();
+
+                //Assert
+                Assert.Equal((HttpStatusCode)httpStatusCode, response.StatusCode);
+
+                //Response should contain a semicolon
+                if (!string.IsNullOrWhiteSpace(statusCodeReasonPhrase))
+                {
+                    Assert.Contains(";", responseBody);
+                }
+                else
+                {
+                    //No reason phrase, so there should not be a semicolon
+                    Assert.DoesNotContain(";", responseBody);
+                }
+
+                //Move to the next status code in the series so the test can be repeated.
+                httpStatusCode++;
+            }
+            while ((httpStatusCode > 400 && httpStatusCode < 600));
         }
     }
 }


### PR DESCRIPTION
Omits the semicolon character when the given HTTP Status Code has no reason phrase.

- Extracted generation of the response body into a seperate method.
- Implemented two unit tests, one to cover each scenario.

Addresses #282 