### PR TITLE
Added support for reading portable PDBs on .NET Framework/Mono apps

### DIFF
--- a/samples/DeveloperExceptionPageSample/project.json
+++ b/samples/DeveloperExceptionPageSample/project.json
@@ -1,15 +1,15 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.1-*",
     "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*"
   },
   "buildOptions": {
-    "emitEntryPoint": true
+    "emitEntryPoint": true,
+    "debugType": "portable"
   },
   "frameworks": {
-    "net451": {},
+    "net451": { },
     "netcoreapp1.0": {
       "imports": [
         "dnxcore50"

--- a/src/Microsoft.AspNetCore.Diagnostics/DeveloperExceptionPage/Views/ErrorDetails.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics/DeveloperExceptionPage/Views/ErrorDetails.cs
@@ -19,6 +19,6 @@ namespace Microsoft.AspNetCore.Diagnostics.Views
         /// <summary>
         /// The generated stack frames
         /// </summary>
-        public IEnumerable<StackFrame> StackFrames { get; set; }
+        public IEnumerable<StackFrameModel> StackFrames { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Diagnostics/DeveloperExceptionPage/Views/ErrorPage.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics/DeveloperExceptionPage/Views/ErrorPage.cs
@@ -124,7 +124,7 @@ WriteAttributeValue("", 512, CultureInfo.CurrentUICulture.TwoLetterISOLanguageNa
 
 #line 35 "ErrorPage.cshtml"
               
-                StackFrame firstFrame = null;
+                StackFrameModel firstFrame = null;
                 firstFrame = errorDetail.StackFrames.FirstOrDefault();
                 if (firstFrame != null)
                 {

--- a/src/Microsoft.AspNetCore.Diagnostics/DeveloperExceptionPage/Views/ErrorPage.cshtml
+++ b/src/Microsoft.AspNetCore.Diagnostics/DeveloperExceptionPage/Views/ErrorPage.cshtml
@@ -1,4 +1,4 @@
-@using System
+﻿@using System
 @using System.Globalization
 @using System.Linq
 @using System.Net
@@ -33,7 +33,7 @@
         {
             <div class="titleerror">@errorDetail.Error.GetType().Name: @{ Output.Write(HtmlEncodeAndReplaceLineBreaks(errorDetail.Error.Message)); }</div>
             @{
-                StackFrame firstFrame = null;
+                StackFrameModel firstFrame = null;
                 firstFrame = errorDetail.StackFrames.FirstOrDefault();
                 if (firstFrame != null)
                 {

--- a/src/Microsoft.AspNetCore.Diagnostics/DeveloperExceptionPage/Views/StackFrameModel.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics/DeveloperExceptionPage/Views/StackFrameModel.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Diagnostics.Views
     /// <summary>
     /// Detailed exception stack information used to generate a view
     /// </summary>
-    public class StackFrame
+    public class StackFrameModel
     {
         /// <summary>
         /// Function containing instruction

--- a/src/Microsoft.AspNetCore.Diagnostics/project.json
+++ b/src/Microsoft.AspNetCore.Diagnostics/project.json
@@ -31,13 +31,15 @@
     "Microsoft.Extensions.FileProviders.Physical": "1.0.0-*",
     "Microsoft.Extensions.Logging.Abstractions": "1.0.0-*",
     "Microsoft.Extensions.Options": "1.0.0-*",
-    "System.Diagnostics.DiagnosticSource": "4.0.0-*"
+    "System.Diagnostics.DiagnosticSource": "4.0.0-*",
+    "System.Reflection.Metadata": "1.3.0-*"
   },
   "frameworks": {
     "net451": {},
     "netstandard1.3": {
       "dependencies": {
-        "System.Reflection.Extensions": "4.0.1-*"
+        "System.Reflection.Extensions": "4.0.1-*",
+        "System.Diagnostics.StackTrace": "4.0.1-*"
       }
     }
   }

--- a/test/Microsoft.AspNetCore.Diagnostics.Tests/DeveloperExceptionPageMiddlewareTest.cs
+++ b/test/Microsoft.AspNetCore.Diagnostics.Tests/DeveloperExceptionPageMiddlewareTest.cs
@@ -22,7 +22,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Xunit;
-using StackFrame = Microsoft.AspNetCore.Diagnostics.Views.StackFrame;
+using StackFrameModel = Microsoft.AspNetCore.Diagnostics.Views.StackFrameModel;
 using Moq;
 
 namespace Microsoft.AspNetCore.Diagnostics
@@ -273,7 +273,7 @@ namespace Microsoft.AspNetCore.Diagnostics
         {
             // Arrange
             var middleware = GetErrorPageMiddleware();
-            var stackFrame = new StackFrame();
+            var stackFrame = new StackFrameModel();
 
             // Act
             middleware.ReadFrameContent(


### PR DESCRIPTION
TODO: Add a test and verify on older mono versions

- Mono 4.4 supports portable PDB and the StackTrace API just works
- This code only kicks in if the filename is null and we're on .NET 4.5.x
- Would be good to test out a dynamic assembly though it should be handled by checking for a null assembly location.

Edit: Mono 4.2.4 crashes and burns with PPDB trying to get the stack trace information:

```C#
Stacktrace:
  at <unknown> <0xffffffff>
  at (wrapper managed-to-native) System.Diagnostics.StackTrace.get_trace (System.Exception,int,bool) <IL 0x00027, 0xffffffff>
  at System.Diagnostics.StackTrace..ctor (System.Exception,int,bool) [0x0002e] in /private/tmp/source-mono-4.2.4/bockbuild-mono-4.2.0-branch/profiles/mono-mac-xamarin/build-root/mono-4.2.4/mcs/class/corlib/System.Diagnostics/StackTrace.cs:129
* Assertion at debug-mono-ppdb.c:217, condition `cols [MONO_METHODBODY_SEQ_POINTS]' not met
  at System.Diagnostics.StackTrace..ctor (System.Exception,bool) [0x00000] in /private/tmp/source-mono-4.2.4/bockbuild-mono-4.2.0-branch/profiles/mono-mac-xamarin/build-root/mono-4.2.4/mcs/class/corlib/System.Diagnostics/StackTrace.cs:113
* Assertion at debug-mono-ppdb.c:217, condition `cols [MONO_METHODBODY_SEQ_POINTS]' not met
```

Need to see if we can detect this and just use our APIs directly. We could always use our these APIs when running on mono if the pdb is a portable pdb. We could also fallback to parsing the stack trace string again (yuck!)

/cc @tmat @pranavkm 

#293