### PR TITLE
fix incorrect pin in 1.0.0 tag

### DIFF
--- a/src/PageGenerator/project.json
+++ b/src/PageGenerator/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-rtm-21431",
+  "version": "1.0.0",
   "description": "Builds the pages for the Diagnostics projects. Runs in build.cmd.",
   "buildOptions": {
     "warningsAsErrors": true,


### PR DESCRIPTION
The `1.0.0` tag has a version of `1.0.0-rtm-21431` for `PageGenerator`, but we actually "shipped" (to our internal feeds) `1.0.0`. This updates the pin to use the correct version so that future builds can accurately locate the previously "released" package on our internal feeds.

/cc @Eilon @pranavkm 

When this is merged, I'll update the `1.0.0` tag to point to the new commit.