### PR TITLE
Added Path property to IExceptionHandlerFeature 

### DIFF
--- a/src/Microsoft.AspNetCore.Diagnostics.Abstractions/IExceptionHandlerFeature.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics.Abstractions/IExceptionHandlerFeature.cs
@@ -9,6 +9,6 @@ namespace Microsoft.AspNetCore.Diagnostics
     {
         Exception Error { get; }
 
-        String Path { get; }
+        string Path { get; }
     }
 }

--- a/src/Microsoft.AspNetCore.Diagnostics.Abstractions/IExceptionHandlerFeature.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics.Abstractions/IExceptionHandlerFeature.cs
@@ -8,6 +8,7 @@ namespace Microsoft.AspNetCore.Diagnostics
     public interface IExceptionHandlerFeature
     {
         Exception Error { get; }
+
         String Path { get; }
     }
 }

--- a/src/Microsoft.AspNetCore.Diagnostics.Abstractions/IExceptionHandlerFeature.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics.Abstractions/IExceptionHandlerFeature.cs
@@ -8,5 +8,6 @@ namespace Microsoft.AspNetCore.Diagnostics
     public interface IExceptionHandlerFeature
     {
         Exception Error { get; }
+        String Path { get; }
     }
 }

--- a/src/Microsoft.AspNetCore.Diagnostics.Abstractions/IExceptionHandlerPathFeature.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics.Abstractions/IExceptionHandlerPathFeature.cs
@@ -1,12 +1,12 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 
 namespace Microsoft.AspNetCore.Diagnostics
 {
-    public interface IExceptionHandlerFeature
+    public interface IExceptionHandlerPathFeature : IExceptionHandlerFeature
     {
-        Exception Error { get; }
+        string Path { get; }
     }
 }

--- a/src/Microsoft.AspNetCore.Diagnostics.Abstractions/IExceptionHandlerPathFeature.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics.Abstractions/IExceptionHandlerPathFeature.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-
 namespace Microsoft.AspNetCore.Diagnostics
 {
     /// <summary>
@@ -11,7 +9,8 @@ namespace Microsoft.AspNetCore.Diagnostics
     public interface IExceptionHandlerPathFeature : IExceptionHandlerFeature
     {
         /// <summary>
-        /// The path of request that caused the exception. The value is un-escaped.
+        /// The portion of the request path that identifies the requested resource. The value
+        /// is un-escaped.
         /// </summary>
         string Path { get; }
     }

--- a/src/Microsoft.AspNetCore.Diagnostics.Abstractions/IExceptionHandlerPathFeature.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics.Abstractions/IExceptionHandlerPathFeature.cs
@@ -5,8 +5,14 @@ using System;
 
 namespace Microsoft.AspNetCore.Diagnostics
 {
+    /// <summary>
+    /// Represents an exception handler with the original path of the request.
+    /// </summary>
     public interface IExceptionHandlerPathFeature : IExceptionHandlerFeature
     {
+        /// <summary>
+        /// The path of request that caused the exception. The value is un-escaped.
+        /// </summary>
         string Path { get; }
     }
 }

--- a/src/Microsoft.AspNetCore.Diagnostics/ExceptionHandler/ExceptionHandlerFeature.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics/ExceptionHandler/ExceptionHandlerFeature.cs
@@ -8,5 +8,7 @@ namespace Microsoft.AspNetCore.Diagnostics
     public class ExceptionHandlerFeature : IExceptionHandlerFeature
     {
         public Exception Error { get; set; }
+
+        public String Path { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Diagnostics/ExceptionHandler/ExceptionHandlerFeature.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics/ExceptionHandler/ExceptionHandlerFeature.cs
@@ -9,6 +9,6 @@ namespace Microsoft.AspNetCore.Diagnostics
     {
         public Exception Error { get; set; }
 
-        public String Path { get; set; }
+        public string Path { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Diagnostics/ExceptionHandler/ExceptionHandlerFeature.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics/ExceptionHandler/ExceptionHandlerFeature.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.AspNetCore.Diagnostics
 {
-    public class ExceptionHandlerFeature : IExceptionHandlerFeature
+    public class ExceptionHandlerFeature : IExceptionHandlerPathFeature
     {
         public Exception Error { get; set; }
 

--- a/src/Microsoft.AspNetCore.Diagnostics/ExceptionHandler/ExceptionHandlerMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics/ExceptionHandler/ExceptionHandlerMiddleware.cs
@@ -68,6 +68,7 @@ namespace Microsoft.AspNetCore.Diagnostics
                         Path = originalPath.Value
                     };
                     context.Features.Set<IExceptionHandlerFeature>(exceptionHandlerFeature);
+                    context.Features.Set<IExceptionHandlerPathFeature>(exceptionHandlerFeature);
                     context.Response.StatusCode = 500;
                     context.Response.OnStarting(_clearCacheHeadersDelegate, context.Response);
 

--- a/src/Microsoft.AspNetCore.Diagnostics/ExceptionHandler/ExceptionHandlerMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics/ExceptionHandler/ExceptionHandlerMiddleware.cs
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Diagnostics
                     var exceptionHandlerFeature = new ExceptionHandlerFeature()
                     {
                         Error = ex,
-                        Path = originalPath.Value
+                        Path = originalPath.Value,
                     };
                     context.Features.Set<IExceptionHandlerFeature>(exceptionHandlerFeature);
                     context.Features.Set<IExceptionHandlerPathFeature>(exceptionHandlerFeature);

--- a/src/Microsoft.AspNetCore.Diagnostics/ExceptionHandler/ExceptionHandlerMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics/ExceptionHandler/ExceptionHandlerMiddleware.cs
@@ -22,8 +22,8 @@ namespace Microsoft.AspNetCore.Diagnostics
         private readonly DiagnosticSource _diagnosticSource;
 
         public ExceptionHandlerMiddleware(
-            RequestDelegate next, 
-            ILoggerFactory loggerFactory, 
+            RequestDelegate next,
+            ILoggerFactory loggerFactory,
             IOptions<ExceptionHandlerOptions> options,
             DiagnosticSource diagnosticSource)
         {
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Diagnostics
 
                 PathString originalPath = context.Request.Path;
                 if (_options.ExceptionHandlingPath.HasValue)
-                {                  
+                {
                     context.Request.Path = _options.ExceptionHandlingPath;
                 }
                 try

--- a/src/Microsoft.AspNetCore.Diagnostics/ExceptionHandler/ExceptionHandlerMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics/ExceptionHandler/ExceptionHandlerMiddleware.cs
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Diagnostics
 
                 PathString originalPath = context.Request.Path;
                 if (_options.ExceptionHandlingPath.HasValue)
-                {
+                {                  
                     context.Request.Path = _options.ExceptionHandlingPath;
                 }
                 try
@@ -65,6 +65,7 @@ namespace Microsoft.AspNetCore.Diagnostics
                     var exceptionHandlerFeature = new ExceptionHandlerFeature()
                     {
                         Error = ex,
+                        Path = originalPath.Value
                     };
                     context.Features.Set<IExceptionHandlerFeature>(exceptionHandlerFeature);
                     context.Response.StatusCode = 500;


### PR DESCRIPTION
In response to #292
The argument for not implementing a second interface and changing the contract on IExceptionHandlerFeature as I understand it is that essentially no one should run into this problem and that most likely only the ExceptionHandlerMiddleware is implementing the interface.
@Tratcher @Eilon 