### PR TITLE
Bump test projects up to .NET 4.5.2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,8 @@ branches:
     - dev
     - /^(.*\/)?ci-.*$/
 build_script:
-  - build.cmd verify
+  - build.cmd --quiet verify
 clone_depth: 1
 test: off
 deploy: off
-os: Visual Studio 2015
+os: Visual Studio 2017 RC

--- a/test/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.FunctionalTests/DatabaseErrorPageMiddlewareTest.cs
+++ b/test/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.FunctionalTests/DatabaseErrorPageMiddlewareTest.cs
@@ -78,7 +78,8 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
         }
 
         [ConditionalFact(Skip = "aspnet/Diagnostics#350")]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task Existing_database_not_using_migrations_exception_passes_thru()
         {
             TestServer server = SetupTestServer<BloggingContext, DatabaseErrorButNoMigrationsMiddleware>();
@@ -106,7 +107,8 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
         }
 
         [ConditionalFact(Skip = "aspnet/Diagnostics#350")]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task Error_page_displayed_no_migrations()
         {
             TestServer server = SetupTestServer<BloggingContext, NoMigrationsMiddleware>();
@@ -134,7 +136,8 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
         }
 
         [ConditionalFact(Skip = "aspnet/Diagnostics#350")]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task Error_page_displayed_pending_migrations()
         {
             TestServer server = SetupTestServer<BloggingContextWithMigrations, PendingMigrationsMiddleware>();
@@ -166,7 +169,8 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
         }
 
         [ConditionalFact(Skip = "aspnet/Diagnostics#350")]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task Error_page_displayed_pending_model_changes()
         {
             TestServer server = SetupTestServer<BloggingContextWithPendingModelChanges, PendingModelChangesMiddleware>();
@@ -197,7 +201,8 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
         }
 
         [ConditionalFact(Skip = "aspnet/Diagnostics#350")]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task Error_page_then_apply_migrations()
         {
             TestServer server = SetupTestServer<BloggingContextWithMigrations, ApplyMigrationsMiddleware>();
@@ -248,7 +253,8 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
         }
 
         [ConditionalFact(Skip = "aspnet/Diagnostics#350")]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task Customize_migrations_end_point()
         {
             var migrationsEndpoint = "/MyCustomEndPoints/ApplyMyMigrationsHere";
@@ -286,7 +292,8 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
         }
 
         [ConditionalFact(Skip = "aspnet/Diagnostics#350")]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task Pass_thru_when_context_not_in_services()
         {
             using (var database = SqlServerTestStore.CreateScratch())
@@ -341,7 +348,8 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
         }
 
         [ConditionalFact(Skip = "aspnet/Diagnostics#350")]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task Pass_thru_when_exception_in_logic()
         {
             using (var database = SqlServerTestStore.CreateScratch())
@@ -373,7 +381,8 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
         }
 
         [ConditionalFact(Skip = "aspnet/Diagnostics#350")]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task Error_page_displayed_when_exception_wrapped()
         {
             TestServer server = SetupTestServer<BloggingContext, WrappedExceptionMiddleware>();

--- a/test/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.FunctionalTests/DatabaseErrorPageMiddlewareTest.cs
+++ b/test/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.FunctionalTests/DatabaseErrorPageMiddlewareTest.cs
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact(Skip = "aspnet/Diagnostics#350")]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task Existing_database_not_using_migrations_exception_passes_thru()
         {
@@ -105,7 +105,7 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact(Skip = "aspnet/Diagnostics#350")]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task Error_page_displayed_no_migrations()
         {
@@ -133,7 +133,7 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact(Skip = "aspnet/Diagnostics#350")]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task Error_page_displayed_pending_migrations()
         {
@@ -165,7 +165,7 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact(Skip = "aspnet/Diagnostics#350")]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task Error_page_displayed_pending_model_changes()
         {
@@ -196,7 +196,7 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact(Skip = "aspnet/Diagnostics#350")]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task Error_page_then_apply_migrations()
         {
@@ -247,7 +247,7 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact(Skip = "aspnet/Diagnostics#350")]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task Customize_migrations_end_point()
         {
@@ -285,7 +285,7 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact(Skip = "aspnet/Diagnostics#350")]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task Pass_thru_when_context_not_in_services()
         {
@@ -340,7 +340,7 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact(Skip = "aspnet/Diagnostics#350")]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task Pass_thru_when_exception_in_logic()
         {
@@ -372,7 +372,7 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact(Skip = "aspnet/Diagnostics#350")]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task Error_page_displayed_when_exception_wrapped()
         {

--- a/test/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.FunctionalTests/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.FunctionalTests.csproj
+++ b/test/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.FunctionalTests/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.FunctionalTests.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.FunctionalTests/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.FunctionalTests.csproj
+++ b/test/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.FunctionalTests/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.FunctionalTests.csproj
@@ -12,8 +12,12 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.2.0-*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.2.0-*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-*" />
     <PackageReference Include="xunit" Version="2.2.0-*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.FunctionalTests/MigrationsEndPointMiddlewareTest.cs
+++ b/test/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.FunctionalTests/MigrationsEndPointMiddlewareTest.cs
@@ -51,14 +51,16 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
         }
 
         [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task Migration_request_default_path()
         {
             await Migration_request(useCustomPath: false);
         }
 
         [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task Migration_request_custom_path()
         {
             await Migration_request(useCustomPath: true);
@@ -188,7 +190,8 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
         }
 
         [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task Exception_while_applying_migrations()
         {
             using (var database = SqlServerTestStore.CreateScratch())

--- a/test/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.FunctionalTests/MigrationsEndPointMiddlewareTest.cs
+++ b/test/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.FunctionalTests/MigrationsEndPointMiddlewareTest.cs
@@ -50,14 +50,14 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task Migration_request_default_path()
         {
             await Migration_request(useCustomPath: false);
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task Migration_request_custom_path()
         {
@@ -187,7 +187,7 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
             Assert.True(content.Length > 512);
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task Exception_while_applying_migrations()
         {

--- a/test/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests/DataStoreErrorLoggerTest.cs
+++ b/test/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests/DataStoreErrorLoggerTest.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
 {
-#if NET451
+#if NET452
     public class DataStoreErrorLoggerTest
     {
         private const string _name = "test";

--- a/test/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests/Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests.csproj
@@ -13,8 +13,12 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.2.0-*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-*" />
     <PackageReference Include="Moq" Version="4.6.36-*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-*" />
     <PackageReference Include="xunit" Version="2.2.0-*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.AspNetCore.Diagnostics.FunctionalTests/Microsoft.AspNetCore.Diagnostics.FunctionalTests.csproj
+++ b/test/Microsoft.AspNetCore.Diagnostics.FunctionalTests/Microsoft.AspNetCore.Diagnostics.FunctionalTests.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
     <RuntimeIdentifier Condition="'$(TargetFramework)'!='netcoreapp1.1'">win7-x64</RuntimeIdentifier>
     <SignAssembly>false</SignAssembly>
     <PublicSign>false</PublicSign>

--- a/test/Microsoft.AspNetCore.Diagnostics.FunctionalTests/Microsoft.AspNetCore.Diagnostics.FunctionalTests.csproj
+++ b/test/Microsoft.AspNetCore.Diagnostics.FunctionalTests/Microsoft.AspNetCore.Diagnostics.FunctionalTests.csproj
@@ -22,8 +22,12 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.2.0-*" />
     <PackageReference Include="Microsoft.AspNetCore.Testing" Version="1.2.0-*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-*" />
     <PackageReference Include="xunit" Version="2.2.0-*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.AspNetCore.Diagnostics.Tests/ElmLoggerTest.cs
+++ b/test/Microsoft.AspNetCore.Diagnostics.Tests/ElmLoggerTest.cs
@@ -305,7 +305,7 @@ namespace Microsoft.AspNetCore.Diagnostics.Tests
             Assert.Empty(store.GetActivities());
         }
 
-#if NET451
+#if NET452
         private static void DomainFunc()
         {
             var t = SetUp();

--- a/test/Microsoft.AspNetCore.Diagnostics.Tests/Microsoft.AspNetCore.Diagnostics.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Diagnostics.Tests/Microsoft.AspNetCore.Diagnostics.Tests.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Diagnostics.Tests/Microsoft.AspNetCore.Diagnostics.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Diagnostics.Tests/Microsoft.AspNetCore.Diagnostics.Tests.csproj
@@ -23,8 +23,12 @@
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="1.2.0-*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-*" />
     <PackageReference Include="Moq" Version="4.6.36-*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-*" />
     <PackageReference Include="xunit" Version="2.2.0-*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.AspNetCore.MiddlewareAnalysis.Tests/Microsoft.AspNetCore.MiddlewareAnalysis.Tests.csproj
+++ b/test/Microsoft.AspNetCore.MiddlewareAnalysis.Tests/Microsoft.AspNetCore.MiddlewareAnalysis.Tests.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.MiddlewareAnalysis.Tests/Microsoft.AspNetCore.MiddlewareAnalysis.Tests.csproj
+++ b/test/Microsoft.AspNetCore.MiddlewareAnalysis.Tests/Microsoft.AspNetCore.MiddlewareAnalysis.Tests.csproj
@@ -15,8 +15,12 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.2.0-*" />
     <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="1.2.0-*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-*" />
     <PackageReference Include="xunit" Version="2.2.0-*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- aspnet/Testing#248
- xUnit no longer supports .NET 4.5.1
- build tests for desktop .NET only on Windows