### PR TITLE
Disable SqlServer specific tests on netcoreapp2.0 on win7/2008

### DIFF
--- a/test/Diagnostics.EFCore.FunctionalTests/MigrationsEndPointMiddlewareTest.cs
+++ b/test/Diagnostics.EFCore.FunctionalTests/MigrationsEndPointMiddlewareTest.cs
@@ -53,6 +53,9 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
         [ConditionalFact]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
+#if NETCOREAPP2_0
+        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win2008R2)]
+#endif
         public async Task Migration_request_default_path()
         {
             await Migration_request(useCustomPath: false);
@@ -61,6 +64,9 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
         [ConditionalFact]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
+#if NETCOREAPP2_0
+        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win2008R2)]
+#endif
         public async Task Migration_request_custom_path()
         {
             await Migration_request(useCustomPath: true);
@@ -192,6 +198,9 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
         [ConditionalFact]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
+#if NETCOREAPP2_0
+        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win2008R2)]
+#endif
         public async Task Exception_while_applying_migrations()
         {
             using (var database = SqlServerTestStore.CreateScratch())

--- a/test/Diagnostics.FunctionalTests/DatabaseErrorPageSampleTest.cs
+++ b/test/Diagnostics.FunctionalTests/DatabaseErrorPageSampleTest.cs
@@ -21,6 +21,9 @@ namespace Microsoft.AspNetCore.Diagnostics.FunctionalTests
         [ConditionalFact]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
+#if NETCOREAPP2_0
+        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win2008R2)]
+#endif
         public async Task DatabaseErrorPage_ShowsError()
         {
             // Arrange


### PR DESCRIPTION
@mikeharder @ryanbrandenburg 
This disables tests which are facing same issue as EF tests.
Manually verified on win7 VM.