### PR TITLE
Re-enable Entity Framework tests

### DIFF
--- a/test/Diagnostics.EFCore.FunctionalTests/MigrationsEndPointMiddlewareTest.cs
+++ b/test/Diagnostics.EFCore.FunctionalTests/MigrationsEndPointMiddlewareTest.cs
@@ -98,9 +98,10 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
                     })
                     .ConfigureServices(services =>
                     {
-                        services.AddEntityFrameworkSqlServer();
-                        services.AddScoped<BloggingContextWithMigrations>();
-                        services.AddSingleton(optionsBuilder.Options);
+                        services.AddDbContext<BloggingContextWithMigrations>(options =>
+                        {
+                            options.UseSqlServer(database.ConnectionString);
+                        });
                     });
                 var server = new TestServer(builder);
 
@@ -205,16 +206,14 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
         {
             using (var database = SqlServerTestStore.CreateScratch())
             {
-                var optionsBuilder = new DbContextOptionsBuilder();
-                optionsBuilder.UseSqlServer(database.ConnectionString);
-
                 var builder = new WebHostBuilder()
                     .Configure(app => app.UseMigrationsEndPoint())
                     .ConfigureServices(services =>
                     {
-                        services.AddEntityFrameworkSqlServer();
-                        services.AddScoped<BloggingContextWithSnapshotThatThrows>();
-                        services.AddSingleton(optionsBuilder.Options);
+                        services.AddDbContext<BloggingContextWithSnapshotThatThrows>(optionsBuilder =>
+                        {
+                            optionsBuilder.UseSqlServer(database.ConnectionString);
+                        });
                     });
                 var server = new TestServer(builder);
 

--- a/test/Diagnostics.EFCore.FunctionalTests/TestModels/BloggingContextWithMigrations.cs
+++ b/test/Diagnostics.EFCore.FunctionalTests/TestModels/BloggingContextWithMigrations.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
 
             protected override void Up(MigrationBuilder migrationBuilder)
             {
-                migrationBuilder.CreateTable("Blog",
+                migrationBuilder.CreateTable("Blogs",
                 c => new
                 {
                     BlogId = c.Column<int>().Annotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn),
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
 
             protected override void Down(MigrationBuilder migrationBuilder)
             {
-                migrationBuilder.DropTable("Blog");
+                migrationBuilder.DropTable("Blogs");
             }
         }
 


### PR DESCRIPTION
Test issues fixed:
* React to using DbSet property name as table name
* React to EF logging changes
* React to updated resource names
* Fix scratch database lifetime issues

Resolves #350 
