### PR TITLE
Remove NetStandaRD.Library.NetFramework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,18 @@ os:
   - linux
   - osx
 osx_image: xcode8.2
+addons:
+  apt:
+    sources:
+      - debian-sid
+    packages:
+      - libunwind8
 branches:
   only:
     - master
     - release
     - dev
+    - /^rel\/.*/
     - /^(.*\/)?ci-.*$/
 before_install:
   - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl; ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi

--- a/build/common.props
+++ b/build/common.props
@@ -16,10 +16,6 @@
     <PackageReference Include="Internal.AspNetCore.Sdk" Version="$(InternalAspNetCoreSdkVersion)" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'">
-    <PackageReference Include="NETStandard.Library.NETFramework" Version="$(NETStandardLibraryNETFrameworkVersion)" PrivateAssets="All" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework' AND '$(OutputType)'=='library'">
     <PackageReference Include="NETStandard.Library" Version="$(NETStandardLibraryImplicitPackageVersion)" />
   </ItemGroup>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,7 +3,7 @@
     <AspNetCoreVersion>2.0.0-*</AspNetCoreVersion>
     <CoreFxVersion>4.4.0-*</CoreFxVersion>
     <InternalAspNetCoreSdkVersion>2.1.0-*</InternalAspNetCoreSdkVersion>
-    <MoqVersion>4.7.1</MoqVersion>
+    <MoqVersion>4.7.49</MoqVersion>
     <NETStandardLibraryImplicitPackageVersion>2.0.0-*</NETStandardLibraryImplicitPackageVersion>
     <NETStandardLibraryNETFrameworkVersion>2.0.0-*</NETStandardLibraryNETFrameworkVersion>
     <RuntimeFrameworkVersion Condition="'$(TargetFramework)'=='netcoreapp2.0'">2.0.0-*</RuntimeFrameworkVersion>


### PR DESCRIPTION
Going through and removing all references to `NETStandard.Library.NETFramework` which don't break the build. I figured while I was touching most of the repos I might as well also update the Moq version. 