### PR TITLE
Remove NetStandardLibraryImplicitPackageVersion

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework' AND '$(OutputType)'=='library'">
-    <PackageReference Include="NETStandard.Library" Version="$(NETStandardLibraryImplicitPackageVersion)" />
+    <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -6,7 +6,6 @@
     <InternalAspNetCoreSdkVersion>2.0.1-*</InternalAspNetCoreSdkVersion>
     <MoqVersion>4.7.49</MoqVersion>
     <NETStandardImplicitPackageVersion>2.0.0-*</NETStandardImplicitPackageVersion>
-    <NETStandardLibraryImplicitPackageVersion>2.0.0-*</NETStandardLibraryImplicitPackageVersion>
     <NETStandardLibraryNETFrameworkVersion>2.0.0-*</NETStandardLibraryNETFrameworkVersion>
     <RuntimeFrameworkVersion Condition="'$(TargetFramework)'=='netcoreapp2.0'">2.0.0-*</RuntimeFrameworkVersion>
     <TestSdkVersion>15.3.0-*</TestSdkVersion>


### PR DESCRIPTION
- For consistency with other repos (e.g. https://github.com/aspnet/Razor/blob/rel/2.0.0/build/common.props#L22)

I created this PR against 2.0 since it's nice to have consistent `*.props` files in case they need to be updated for servicing.  However, I'm also fine merging this to dev but not 2.0.