### PR TITLE
Test: fix status code order

### DIFF
--- a/test/Diagnostics.EFCore.FunctionalTests/DatabaseErrorPageMiddlewareTest.cs
+++ b/test/Diagnostics.EFCore.FunctionalTests/DatabaseErrorPageMiddlewareTest.cs
@@ -46,8 +46,8 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
 
             public virtual async Task Invoke(HttpContext context)
             {
-                await context.Response.WriteAsync("Request Handled");
                 context.Response.StatusCode = (int)HttpStatusCode.OK;
+                await context.Response.WriteAsync("Request Handled");
             }
         }
 

--- a/test/Diagnostics.EFCore.FunctionalTests/MigrationsEndPointMiddlewareTest.cs
+++ b/test/Diagnostics.EFCore.FunctionalTests/MigrationsEndPointMiddlewareTest.cs
@@ -45,8 +45,8 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
 
             public virtual async Task Invoke(HttpContext context)
             {
-                await context.Response.WriteAsync("Request Handled");
                 context.Response.StatusCode = (int)HttpStatusCode.OK;
+                await context.Response.WriteAsync("Request Handled");
             }
         }
 


### PR DESCRIPTION
This is a reaction to the TestServer improvements. It's invalid to set the status code after writing to the response. See https://github.com/aspnet/Hosting/pull/1256