### PR TITLE
Blocking detection in Development

### DIFF
--- a/src/Microsoft.AspNetCore.Diagnostics/BlockingDetection/DetectBlocking.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics/BlockingDetection/DetectBlocking.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using Microsoft.AspNetCore.Diagnostics.Internal;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Diagnostics
+{
+    // Tips of the Toub
+    internal sealed class DetectBlocking : SynchronizationContext
+    {
+        [ThreadStatic]
+        private static int t_recursionCount;
+
+        private readonly ILogger _logger;
+
+        public DetectBlocking(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger<DetectBlocking>();
+
+            SetWaitNotificationRequired();
+        } 
+
+        public override int Wait(IntPtr[] waitHandles, bool waitAll, int millisecondsTimeout)
+        {
+            t_recursionCount++;
+
+            try
+            {
+                if (t_recursionCount == 1 && Thread.CurrentThread.IsThreadPoolThread)
+                {
+                    _logger.BlockingMethodCalled(new StackTrace());
+                }
+
+                return base.Wait(waitHandles, waitAll, millisecondsTimeout);
+            }
+            finally
+            {
+                t_recursionCount--;
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Diagnostics/Internal/DiagnosticsLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics/Internal/DiagnosticsLoggerExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Diagnostics.Internal
@@ -26,6 +27,10 @@ namespace Microsoft.AspNetCore.Diagnostics.Internal
         private static readonly Action<ILogger, Exception> _displayErrorPageException =
             LoggerMessage.Define(LogLevel.Error, new EventId(3, "DisplayErrorPageException"), "An exception was thrown attempting to display the error page.");
 
+        // BlockingDetection
+        private static readonly Action<ILogger, StackTrace, Exception> _blockingMethodCalled =
+            LoggerMessage.Define<StackTrace>(LogLevel.Warning, new EventId(4, "BlockingMethodCalled"), "Blocking method has been invoked and blocked, this can lead to threadpool starvation." + Environment.NewLine + "{stackTrace}");
+
         public static void UnhandledException(this ILogger logger, Exception exception)
         {
             _unhandledException(logger, exception);
@@ -49,6 +54,11 @@ namespace Microsoft.AspNetCore.Diagnostics.Internal
         public static void DisplayErrorPageException(this ILogger logger, Exception exception)
         {
             _displayErrorPageException(logger, exception);
+        }
+
+        public static void BlockingMethodCalled(this ILogger logger, StackTrace stackTrace)
+        {
+            _blockingMethodCalled(logger, stackTrace, null);
         }
     }
 }


### PR DESCRIPTION
Warning when blocking calls are made on the threadpool.

Doesn't detect everything...

1. Won't alert for  blocking on precompleted tasks (e.g. a single small `Body.Write`)
2. Won't alert for blocking that happens in syscalls (e.g. `File.Read(...)`, `Thread.Sleep`)

Will detect CLR initiated waits `lock`,`ManualResetEventSlim`,`Semaphore{Slim}`,`Task.Wait`,`Task.Result` etc; if they do block.

e.g. if you had a method like:

```csharp
public Task BlockingWrite(HttpContext httpContext)
{
    var response = httpContext.Response;
    response.StatusCode = 200;
    response.ContentType = "text/plain";

    var s = new string('n', 160000);
    response.ContentLength = s.Length * 3;
    response.Body.Write(Encoding.ASCII.GetBytes(s), 0, s.Length);
    response.Body.Write(Encoding.ASCII.GetBytes(s), 0, s.Length);
    response.Body.Write(Encoding.ASCII.GetBytes(s), 0, s.Length);

    return Task.CompletedTask;
}
```
And `UseDeveloperExceptionPage` is added, it will ouput
```
warn: Microsoft.AspNetCore.Diagnostics.DetectBlocking[6]
      Blocking method has been invoked and blocked, this can lead to threadpool starvation.
         at System.Threading.ManualResetEventSlim.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
         at System.Threading.Tasks.Task.SpinThenBlockingWait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
         at System.Threading.Tasks.Task.InternalWait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
         at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.FrameResponseStream.Write(Byte[] buffer, Int32 offset, Int32 count)
         at AoA.Gaia.Startup.BlockingWrite(HttpContext httpContext)
         at AoA.Gaia.SpaceWebSocketsMiddleware.Invoke(HttpContext httpContext)
         at Microsoft.AspNetCore.WebSockets.WebSocketMiddleware.Invoke(HttpContext context)
         at AoA.Space.ErrorHandlerMiddleware.<Invoke>d__4.MoveNext()
         at System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start[TStateMachine](TStateMachine& stateMachine)
         at AoA.Space.ErrorHandlerMiddleware.Invoke(HttpContext httpContext)
         at Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware.<Invoke>d__7.MoveNext()
         at System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start[TStateMachine](TStateMachine& stateMachine)
         at Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware.Invoke(HttpContext context)
         at AoA.Gaia.BlockingDetection.BlockingDetectionMiddleware.<Invoke>d__3.MoveNext()
         at System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start[TStateMachine](TStateMachine& stateMachine)
         at AoA.Gaia.BlockingDetection.BlockingDetectionMiddleware.Invoke(HttpContext httpContext)
         at Microsoft.AspNetCore.Hosting.Internal.RequestServicesContainerMiddleware.<Invoke>d__3.MoveNext()
         at System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start[TStateMachine](TStateMachine& stateMachine)
         at Microsoft.AspNetCore.Hosting.Internal.RequestServicesContainerMiddleware.Invoke(HttpContext httpContext)
         at Microsoft.AspNetCore.Hosting.Internal.HostingApplication.ProcessRequestAsync(Context context)
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.Frame`1.<ProcessRequestsAsync>d__2.MoveNext()
         at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
         at Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines.Pipe.<>c.<.cctor>b__67_3(Object o)
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.LoggingThreadPool.<>c__DisplayClass6_0.<Schedule>b__0()
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.LoggingThreadPool.<RunAction>b__3_0(Object o)
         at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
         at System.Threading.ThreadPoolWorkQueue.Dispatch()
```

/cc @davidfowl @stephentoub 