### PR TITLE
Populate the exception handler feature

### DIFF
--- a/src/Microsoft.AspNetCore.Diagnostics/DeveloperExceptionPage/DeveloperExceptionPageFeature.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics/DeveloperExceptionPage/DeveloperExceptionPageFeature.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Diagnostics
+{
+  public class DeveloperExceptionPageFeature : IExceptionHandlerFeature
+  {
+    public Exception Error { get; set; }
+  }
+}

--- a/src/Microsoft.AspNetCore.Diagnostics/DeveloperExceptionPage/DeveloperExceptionPageMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics/DeveloperExceptionPage/DeveloperExceptionPageMiddleware.cs
@@ -86,6 +86,11 @@ namespace Microsoft.AspNetCore.Diagnostics
                 try
                 {
                     context.Response.Clear();
+                    var exceptionHandlerFeature = new DeveloperExceptionPageFeature()
+                    {
+                        Error = ex,
+                    };
+                    context.Features.Set<IExceptionHandlerFeature>(exceptionHandlerFeature);
                     context.Response.StatusCode = 500;
 
                     await DisplayException(context, ex);


### PR DESCRIPTION
Populate the `IExceptionHandlerFeature` when swallowing exceptions in the `DeveloperExceptionPageMiddleware`, following the same pattern as `ExceptionHandlerMiddleware`. 

This is useful for building error reporting middleware that needs to send exceptions from development.

Outstanding questions:

- I have only populated `IExceptionHandlerFeature` and not populated `IExceptionHandlerPathFeature`, should we also populate this feature as per `ExceptionHandlerMiddleware`?
- Is it common practice to implement the feature interfaces in individual classes or should this share the `ExceptionHandlerFeature` class that `ExceptionHandlerMiddleware` uses?
- I could not find any tests that check for features being populated, do you need me to write some?