### PR TITLE
Add filtering to Health Checks middleware

### DIFF
--- a/samples/HealthChecksSample/LivenessProbeStartup.cs
+++ b/samples/HealthChecksSample/LivenessProbeStartup.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace HealthChecksSample
+{
+    // Pass in `--scenario liveness` at the command line to run this sample.
+    public class LivenessProbeStartup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            // Registers required services for health checks
+            services
+                .AddHealthChecks()
+                .AddCheck("identity", () => Task.FromResult(HealthCheckResult.Healthy()))
+                .AddCheck(new SlowDependencyHealthCheck());
+        }
+
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            // This will register the health checks middleware twice:
+            // - at /health/ready for 'readiness'
+            // - at /health/live for 'liveness'
+            //
+            // Using a separate liveness and readiness check is useful in an environment like Kubernetes
+            // when an application needs to do significant work before accepting requests. Using separate
+            // checks allows the orchestrator to distinguish whether the application is functioning but 
+            // not yet ready or if the application has failed to start.
+            //
+            // For instance the liveness check will do a quick set of checks to determine if the process
+            // is functioning correctly.
+            //
+            // The readiness check might do a set of more expensive or time-consuming checks to determine
+            // if all other resources are responding.
+            //
+            // See https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/ for
+            // more details about readiness and liveness probes in Kubernetes.
+            //
+            // In this example, the liveness check will us an 'identity' check that always returns healthy.
+            //
+            // In this example, the readiness check will run all registered checks, include a check with an 
+            // long initialization time (15 seconds).
+
+
+            // The readiness check uses all of the registered health checks (default)
+            app.UseHealthChecks("/health/ready", new HealthCheckOptions()
+            {
+                // This sample is using detailed status to make more apparent which checks are being run - any
+                // output format will work with liveness and readiness checks.
+                ResponseWriter = HealthCheckResponseWriters.WriteDetailedJson,
+            });
+
+            // The liveness check uses an 'identity' health check that always returns healty
+            app.UseHealthChecks("/health/live", new HealthCheckOptions()
+            {
+                // Filters the set of health checks run by this middleware
+                HealthCheckNames =
+                {
+                    "identity",
+                },
+
+                // This sample is using detailed status to make more apparent which checks are being run - any
+                // output format will work with liveness and readiness checks.
+                ResponseWriter = HealthCheckResponseWriters.WriteDetailedJson,
+            });
+
+            app.Run(async (context) =>
+            {
+                await context.Response.WriteAsync("Go to /health/ready to see the readiness status");
+                await context.Response.WriteAsync(Environment.NewLine);
+                await context.Response.WriteAsync("Go to /health/live to see the liveness status");
+            });
+        }
+    }
+}

--- a/samples/HealthChecksSample/Program.cs
+++ b/samples/HealthChecksSample/Program.cs
@@ -18,6 +18,7 @@ namespace HealthChecksSample
                 { "basic", typeof(BasicStartup) },
                 { "detailed", typeof(DetailedStatusStartup) },
                 { "writer", typeof(CustomWriterStartup) },
+                { "liveness", typeof(LivenessProbeStartup) },
             };
         }
 

--- a/samples/HealthChecksSample/SlowDependencyHealthCheck.cs
+++ b/samples/HealthChecksSample/SlowDependencyHealthCheck.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace HealthChecksSample
+{
+    // Simulates a health check for an  application dependency that takes a while to initialize.
+    // This is part of the readiness/liveness probe sample.
+    public class SlowDependencyHealthCheck : IHealthCheck
+    {
+        public static readonly string HealthCheckName = "slow_dependency";
+
+        private readonly Task _task;
+
+        public SlowDependencyHealthCheck()
+        {
+            _task = Task.Delay(15 * 1000);
+        }
+
+        public string Name => HealthCheckName;
+
+        public Task<HealthCheckResult> CheckHealthAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (_task.IsCompleted)
+            {
+                return Task.FromResult(HealthCheckResult.Healthy("Dependency is ready"));
+            }
+
+            return Task.FromResult(HealthCheckResult.Unhealthy("Dependency is still initializing"));
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Diagnostics.HealthChecks/HealthCheckOptions.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics.HealthChecks/HealthCheckOptions.cs
@@ -14,6 +14,16 @@ namespace Microsoft.AspNetCore.Diagnostics.HealthChecks
     /// </summary>
     public class HealthCheckOptions
     {
+        /// <summary>
+        /// Gets a set of health check names used to filter the set of health checks run.
+        /// </summary>
+        /// <remarks>
+        /// If <see cref="HealthCheckNames"/> is empty, the <see cref="HealthCheckMiddleware"/> will run all
+        /// registered health checks - this is the default behavior. To run a subset of health checks,
+        /// add the names of the desired health checks.
+        /// </remarks>
+        public ISet<string> HealthCheckNames { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         public IDictionary<HealthCheckStatus, int> ResultStatusCodes { get; } = new Dictionary<HealthCheckStatus, int>()
         {
             { HealthCheckStatus.Healthy, StatusCodes.Status200OK },


### PR DESCRIPTION
This allows each middleware to be configured with a specific set of
checks (by name). See the comments in the sample for how this is
frequently used.

This is also addresses aspnet/Home#2575 - or at least the part that we
plan to do. We think that any sort of built-in system of metadata or
tags is vast overkill, and doesn't really align with the primary usage
of health checks.

We're providing building blocks, and these can be put together to
build more complicated things like what's described in aspnet/Home#2575.