### PR TITLE
Improved logging for health checks

### DIFF
--- a/samples/HealthChecksSample/GCInfoHealthCheck.cs
+++ b/samples/HealthChecksSample/GCInfoHealthCheck.cs
@@ -65,8 +65,8 @@ namespace HealthChecksSample
                 { "Gen2Collections", GC.CollectionCount(2) },
             };
 
-            // Report failure if the allocated memory is >= the threshold
-            var result = allocated >= options.Threshold;
+            // Report failure if the allocated memory is >= the threshold. Negated because true == success
+            var result = !(allocated >= options.Threshold);
 
             return Task.FromResult(new HealthCheckResult(
                 result,

--- a/samples/HealthChecksSample/Program.cs
+++ b/samples/HealthChecksSample/Program.cs
@@ -15,7 +15,7 @@ namespace HealthChecksSample
         {
             _scenarios = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase)
             {
-                { "", typeof(DBHealthStartup) },
+                { "", typeof(CustomWriterStartup) },
                 { "basic", typeof(BasicStartup) },
                 { "writer", typeof(CustomWriterStartup) },
                 { "liveness", typeof(LivenessProbeStartup) },


### PR DESCRIPTION
- Add logging of description/data
- Add logging for aggregate begin/end

```
dbug: Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService[100]
      Running health checks
dbug: Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService[102]
      Running health check GCInfo
dbug: Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService[103]
      Health check GCInfo completed after 3.5313ms with status Degraded and 'reports degraded status if allocated bytes >= 1gb'
dbug: Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService[105]
      Health check data for GCInfo:
          Allocated: 1636848
          Gen0Collections: 0
          Gen1Collections: 0
          Gen2Collections: 0
          HealthCheckName: GCInfo

dbug: Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService[101]
      Health check processing completed after 20.6395ms with combined status Degraded
dbug: Microsoft.AspNetCore.Server.Kestrel[9]
```