### PR TITLE
Added execution time duration (HealthReportEntry TotalDuration)

### DIFF
--- a/src/Microsoft.Extensions.Diagnostics.HealthChecks/DefaultHealthCheckService.cs
+++ b/src/Microsoft.Extensions.Diagnostics.HealthChecks/DefaultHealthCheckService.cs
@@ -73,15 +73,16 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
                         try
                         {
                             var result = await healthCheck.CheckHealthAsync(context, cancellationToken);
+                            var duration = stopwatch.GetElapsedTime();
 
                             entry = new HealthReportEntry(
                                 status: result.Result ? HealthStatus.Healthy : registration.FailureStatus,
                                 description: result.Description,
-                                duration: stopwatch.GetElapsedTime(),
+                                duration: duration,
                                 exception: result.Exception,
                                 data: result.Data);
 
-                            Log.HealthCheckEnd(_logger, registration, entry, stopwatch.GetElapsedTime());
+                            Log.HealthCheckEnd(_logger, registration, entry, duration);
                             Log.HealthCheckData(_logger, registration, entry);
                         }
 

--- a/src/Microsoft.Extensions.Diagnostics.HealthChecks/DefaultHealthCheckService.cs
+++ b/src/Microsoft.Extensions.Diagnostics.HealthChecks/DefaultHealthCheckService.cs
@@ -89,14 +89,15 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
                         // Allow cancellation to propagate.
                         catch (Exception ex) when (ex as OperationCanceledException == null)
                         {
+                            var duration = stopwatch.GetElapsedTime();
                             entry = new HealthReportEntry(
                                 status: HealthStatus.Failed,
                                 description: ex.Message,
-                                duration: stopwatch.GetElapsedTime(),
+                                duration: duration,
                                 exception: ex,
                                 data: null);
 
-                            Log.HealthCheckError(_logger, registration, ex, stopwatch.GetElapsedTime());
+                            Log.HealthCheckError(_logger, registration, ex, duration);
                         }
 
                         entries[registration.Name] = entry;

--- a/src/Microsoft.Extensions.Diagnostics.HealthChecks/HealthReport.cs
+++ b/src/Microsoft.Extensions.Diagnostics.HealthChecks/HealthReport.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Microsoft.Extensions.Diagnostics.HealthChecks
 {
@@ -16,7 +15,7 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
         /// Create a new <see cref="HealthReport"/> from the specified results.
         /// </summary>
         /// <param name="entries">A <see cref="IReadOnlyDictionary{TKey, T}"/> containing the results from each health check.</param>
-        /// <param name="totalDuration">A value indicating the total duration of executing <paramref name="entries"/>.</param>
+        /// <param name="totalDuration">A value indicating the time the health check service took to execute.</param>
         public HealthReport(IReadOnlyDictionary<string, HealthReportEntry> entries, TimeSpan totalDuration)
         {
             Entries = entries;
@@ -40,7 +39,7 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
         public HealthStatus Status { get; }
 
         /// <summary>
-        /// Gets the total duration of executing a group of <see cref="IHealthCheck"/> instances.
+        /// Gets the time the health check service took to execute.
         /// </summary>
         public TimeSpan TotalDuration { get; }
 

--- a/src/Microsoft.Extensions.Diagnostics.HealthChecks/HealthReport.cs
+++ b/src/Microsoft.Extensions.Diagnostics.HealthChecks/HealthReport.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Extensions.Diagnostics.HealthChecks
 {
@@ -14,10 +16,12 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
         /// Create a new <see cref="HealthReport"/> from the specified results.
         /// </summary>
         /// <param name="entries">A <see cref="IReadOnlyDictionary{TKey, T}"/> containing the results from each health check.</param>
-        public HealthReport(IReadOnlyDictionary<string, HealthReportEntry> entries)
+        /// <param name="totalDuration">A value indicating the total duration of executing <paramref name="entries"/>.</param>
+        public HealthReport(IReadOnlyDictionary<string, HealthReportEntry> entries, TimeSpan totalDuration)
         {
             Entries = entries;
             Status = CalculateAggregateStatus(entries.Values);
+            TotalDuration = totalDuration;
         }
 
         /// <summary>
@@ -34,6 +38,11 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
         /// will be the most servere status reported by a health check. If no checks were executed, the value is always <see cref="HealthStatus.Healthy"/>.
         /// </summary>
         public HealthStatus Status { get; }
+
+        /// <summary>
+        /// Gets the total duration of executing a group of <see cref="IHealthCheck"/> instances.
+        /// </summary>
+        public TimeSpan TotalDuration { get; }
 
         private HealthStatus CalculateAggregateStatus(IEnumerable<HealthReportEntry> entries)
         {

--- a/src/Microsoft.Extensions.Diagnostics.HealthChecks/HealthReportEntry.cs
+++ b/src/Microsoft.Extensions.Diagnostics.HealthChecks/HealthReportEntry.cs
@@ -19,12 +19,14 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
         /// </summary>
         /// <param name="status">A value indicating the health status of the component that was checked.</param>
         /// <param name="description">A human-readable description of the status of the component that was checked.</param>
+        /// <param name="duration">A value indicating the health execution duration.</param>
         /// <param name="exception">An <see cref="Exception"/> representing the exception that was thrown when checking for status (if any).</param>
         /// <param name="data">Additional key-value pairs describing the health of the component.</param>
-        public HealthReportEntry(HealthStatus status, string description, Exception exception, IReadOnlyDictionary<string, object> data)
+        public HealthReportEntry(HealthStatus status, string description,TimeSpan duration, Exception exception, IReadOnlyDictionary<string, object> data)
         {
             Status = status;
             Description = description;
+            Duration = duration;
             Exception = exception;
             Data = data ?? _emptyReadOnlyDictionary;
         }
@@ -38,6 +40,11 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
         /// Gets a human-readable description of the status of the component that was checked.
         /// </summary>
         public string Description { get; }
+
+        /// <summary>
+        /// Gets the health check execution duration.
+        /// </summary>
+        public TimeSpan Duration { get; }
 
         /// <summary>
         /// Gets an <see cref="System.Exception"/> representing the exception that was thrown when checking for status (if any).

--- a/src/Microsoft.Extensions.Diagnostics.HealthChecks/HealthReportEntry.cs
+++ b/src/Microsoft.Extensions.Diagnostics.HealthChecks/HealthReportEntry.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
         /// <param name="duration">A value indicating the health execution duration.</param>
         /// <param name="exception">An <see cref="Exception"/> representing the exception that was thrown when checking for status (if any).</param>
         /// <param name="data">Additional key-value pairs describing the health of the component.</param>
-        public HealthReportEntry(HealthStatus status, string description,TimeSpan duration, Exception exception, IReadOnlyDictionary<string, object> data)
+        public HealthReportEntry(HealthStatus status, string description, TimeSpan duration, Exception exception, IReadOnlyDictionary<string, object> data)
         {
             Status = status;
             Description = description;

--- a/test/Microsoft.Extensions.Diagnostics.HealthChecks.Tests/HealthReportTest.cs
+++ b/test/Microsoft.Extensions.Diagnostics.HealthChecks.Tests/HealthReportTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using Xunit;
 
@@ -17,15 +18,29 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
         {
             var result = new HealthReport(new Dictionary<string, HealthReportEntry>()
             {
-                {"Foo", new HealthReportEntry(HealthStatus.Healthy, null, null, null) },
-                {"Bar", new HealthReportEntry(HealthStatus.Healthy, null, null, null) },
-                {"Baz", new HealthReportEntry(status, exception: null, description: null, data: null) },
-                {"Quick", new HealthReportEntry(HealthStatus.Healthy, null, null, null) },
-                {"Quack", new HealthReportEntry(HealthStatus.Healthy, null, null, null) },
-                {"Quock", new HealthReportEntry(HealthStatus.Healthy, null, null, null) },
-            });
+                {"Foo", new HealthReportEntry(HealthStatus.Healthy, null,TimeSpan.MinValue, null, null) },
+                {"Bar", new HealthReportEntry(HealthStatus.Healthy, null, TimeSpan.MinValue,null, null) },
+                {"Baz", new HealthReportEntry(status, exception: null, description: null,duration:TimeSpan.MinValue, data: null) },
+                {"Quick", new HealthReportEntry(HealthStatus.Healthy, null, TimeSpan.MinValue, null, null) },
+                {"Quack", new HealthReportEntry(HealthStatus.Healthy, null, TimeSpan.MinValue, null, null) },
+                {"Quock", new HealthReportEntry(HealthStatus.Healthy, null, TimeSpan.MinValue, null, null) },
+            }, totalDuration: TimeSpan.MinValue);
 
             Assert.Equal(status, result.Status);
+        }
+
+        [Theory]
+        [InlineData(200)]
+        [InlineData(300)]
+        [InlineData(400)]
+        public void TotalDuration_MatchesTotalDurationParameter(int milliseconds)
+        {
+            var result = new HealthReport(new Dictionary<string, HealthReportEntry>()
+            {
+                {"Foo", new HealthReportEntry(HealthStatus.Healthy, null,TimeSpan.MinValue, null, null) }
+            }, totalDuration: TimeSpan.FromMilliseconds(milliseconds));
+
+            Assert.Equal(TimeSpan.FromMilliseconds(milliseconds), result.TotalDuration);
         }
     }
 }


### PR DESCRIPTION
Hi @rynowak 

This is the PR related with the issue #491. 

HealthReport total duration is setted using the totaltime you mentioned on the issue, my only doubt is whether this time should not be aggregated from the report entry times.

Thanks