### PR TITLE
Adjust font-weight to make it easier to read

### DIFF
--- a/src/Microsoft.AspNetCore.Diagnostics/DeveloperExceptionPage/Views/ErrorPage.css
+++ b/src/Microsoft.AspNetCore.Diagnostics/DeveloperExceptionPage/Views/ErrorPage.css
@@ -6,8 +6,7 @@
 }
 
 h1, h2, h3, h4, h5 {
-    /*font-family: 'Segoe UI',Tahoma,Arial,Helvetica,sans-serif;*/
-    font-weight: 100;
+    font-weight: 400;
 }
 
 h1 {
@@ -26,6 +25,7 @@ h3 {
 
 code {
     font-family: Consolas, "Courier New", courier, monospace;
+    font-weight: 600;
 }
 
 body .titleerror {

--- a/src/Microsoft.AspNetCore.Diagnostics/DeveloperExceptionPage/Views/ErrorPage.css
+++ b/src/Microsoft.AspNetCore.Diagnostics/DeveloperExceptionPage/Views/ErrorPage.css
@@ -5,10 +5,6 @@
     background-color: #fff;
 }
 
-h1, h2, h3, h4, h5 {
-    font-weight: 400;
-}
-
 h1 {
     color: #44525e;
     margin: 15px 0 15px 0;
@@ -21,11 +17,12 @@ h2 {
 h3 {
     color: #363636;
     margin: 5px 5px 0 0;
+    font-weight: normal;
 }
 
 code {
     font-family: Consolas, "Courier New", courier, monospace;
-    font-weight: 600;
+    font-weight: bold;
 }
 
 body .titleerror {


### PR DESCRIPTION
Personally I've found the developer exception page can be hard to read with the really thin font-weight even with 20/20 vision.

Below is an example of the default on a 1.5 device pixel ratio screen for chrome, edge & firefox.
![chromeedgefirefox-1_5dppx-default](https://user-images.githubusercontent.com/1302542/46707006-d9749880-cc05-11e8-91be-864fe5de5e82.PNG)

Below is a screenshot with what I'm suggesting with this pull request. 
![chromeedgefirefox-1_5dppx-code_fontweight600-h1h2h3h4h5_fontweight400](https://user-images.githubusercontent.com/1302542/46707012-e7c2b480-cc05-11e8-8522-92ed6fabf546.PNG)

Obviously with different people, devices, browsers, fonts, settings, etc - this can be considered subjective, so if you think I should create an issue on the Home repo to get other people's feedback, let me know.

I also removed the commented out declaration.
