### PR TITLE
Fixed broken link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 Contributing
 ======
 
-Information on contributing to this repo is in the [Contributing Guide](https://github.com/aspnet/Home/blob/dev/CONTRIBUTING.md) in the Home repo.
+Information on contributing to this repo is in the [Contributing Guide](https://github.com/aspnet/AspNetCore/blob/master/CONTRIBUTING.md) in the AspNetCore repo.


### PR DESCRIPTION
Summary of changes:
 - Updated the link in CONTRIBUTING.md
 - Rewrote from Home to AspNetCore in CONTRIBUTING.md

The link (https://github.com/aspnet/Home/blob/dev/CONTRIBUTING.md) was broken due to rename from home to AspNetCore and missing dev branch.