### PR TITLE
Rename anti-caching option

### DIFF
--- a/src/Microsoft.AspNetCore.Diagnostics.HealthChecks/HealthCheckMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics.HealthChecks/HealthCheckMiddleware.cs
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Diagnostics.HealthChecks
 
             httpContext.Response.StatusCode = statusCode;
 
-            if (!_healthCheckOptions.SuppressCacheHeaders)
+            if (!_healthCheckOptions.AllowCachingResponses)
             {
                 // Similar to: https://github.com/aspnet/Security/blob/7b6c9cf0eeb149f2142dedd55a17430e7831ea99/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationHandler.cs#L377-L379
                 var headers = httpContext.Response.Headers;

--- a/src/Microsoft.AspNetCore.Diagnostics.HealthChecks/HealthCheckOptions.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics.HealthChecks/HealthCheckOptions.cs
@@ -48,11 +48,19 @@ namespace Microsoft.AspNetCore.Diagnostics.HealthChecks
         public Func<HttpContext, HealthReport, Task> ResponseWriter { get; set; } = HealthCheckResponseWriters.WriteMinimalPlaintext;
 
         /// <summary>
-        /// Gets or sets a value that controls whether the health check middleware will add HTTP headers to prevent
-        /// response caching. If the value is <c>false</c> the health check middleware will set or override the 
+        /// Gets or sets a value that controls whether responses from the health check middleware can be cached.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The health check middleware does not perform caching of any kind. This setting configures whether
+        /// the middleware will apply headers to the HTTP response that instruct clients to avoid caching.
+        /// </para>
+        /// <para>
+        /// If the value is <c>false</c> the health check middleware will set or override the 
         /// <c>Cache-Control</c>, <c>Expires</c>, and <c>Pragma</c> headers to prevent response caching. If the value 
         /// is <c>true</c> the health check middleware will not modify the cache headers of the response.
-        /// </summary>
-        public bool SuppressCacheHeaders { get; set; }
+        /// </para>
+        /// </remarks>
+        public bool AllowCachingResponses { get; set; }
     }
 }

--- a/test/Microsoft.AspNetCore.Diagnostics.HealthChecks.Tests/HealthCheckMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.Diagnostics.HealthChecks.Tests/HealthCheckMiddlewareTests.cs
@@ -324,7 +324,7 @@ namespace Microsoft.AspNetCore.Diagnostics.HealthChecks
                 {
                     app.UseHealthChecks("/health", new HealthCheckOptions()
                     {
-                        SuppressCacheHeaders = true,
+                        AllowCachingResponses = true,
                     });
                 })
                 .ConfigureServices(services =>


### PR DESCRIPTION
- Renamed the property for configuration response caching headers
- Renamed the options class to avoid conflicts with other type names

Fixes https://github.com/aspnet/Diagnostics/issues/509