### PR TITLE
Redesign HealthStatus (again)

### DIFF
--- a/samples/HealthChecksSample/DbConnectionHealthCheck.cs
+++ b/samples/HealthChecksSample/DbConnectionHealthCheck.cs
@@ -51,7 +51,7 @@ namespace HealthChecksSample
                 }
                 catch (DbException ex)
                 {
-                    return HealthCheckResult.Unhealthy(exception: ex);
+                    return new HealthCheckResult(status: context.Registration.FailureStatus, exception: ex);
                 }
             }
 

--- a/samples/HealthChecksSample/DbConnectionHealthCheck.cs
+++ b/samples/HealthChecksSample/DbConnectionHealthCheck.cs
@@ -51,11 +51,11 @@ namespace HealthChecksSample
                 }
                 catch (DbException ex)
                 {
-                    return HealthCheckResult.Failed(exception: ex);
+                    return HealthCheckResult.Unhealthy(exception: ex);
                 }
             }
 
-            return HealthCheckResult.Passed();
+            return HealthCheckResult.Healthy();
         }
     }
 }

--- a/samples/HealthChecksSample/GCInfoHealthCheck.cs
+++ b/samples/HealthChecksSample/GCInfoHealthCheck.cs
@@ -74,7 +74,6 @@ namespace HealthChecksSample
             return Task.FromResult(new HealthCheckResult(
                 result,
                 description: "reports degraded status if allocated bytes >= 1gb",
-                exception: null,
                 data: data));
         }
     }

--- a/samples/HealthChecksSample/GCInfoHealthCheck.cs
+++ b/samples/HealthChecksSample/GCInfoHealthCheck.cs
@@ -65,8 +65,11 @@ namespace HealthChecksSample
                 { "Gen2Collections", GC.CollectionCount(2) },
             };
 
-            // Report failure if the allocated memory is >= the threshold. Negated because true == success
-            var result = !(allocated >= options.Threshold);
+            // Report failure if the allocated memory is >= the threshold.
+            //
+            // Using context.Registration.FailureStatus means that the application developer can configure
+            // how they want failures to appear.
+            var result = allocated >= options.Threshold ? context.Registration.FailureStatus : HealthStatus.Healthy;
 
             return Task.FromResult(new HealthCheckResult(
                 result,

--- a/samples/HealthChecksSample/SlowDependencyHealthCheck.cs
+++ b/samples/HealthChecksSample/SlowDependencyHealthCheck.cs
@@ -21,10 +21,10 @@ namespace HealthChecksSample
         {
             if (_task.IsCompleted)
             {
-                return Task.FromResult(HealthCheckResult.Passed("Dependency is ready"));
+                return Task.FromResult(HealthCheckResult.Healthy("Dependency is ready"));
             }
 
-            return Task.FromResult(HealthCheckResult.Failed("Dependency is still initializing"));
+            return Task.FromResult(HealthCheckResult.Unhealthy("Dependency is still initializing"));
         }
     }
 }

--- a/samples/HealthChecksSample/SlowDependencyHealthCheck.cs
+++ b/samples/HealthChecksSample/SlowDependencyHealthCheck.cs
@@ -24,7 +24,9 @@ namespace HealthChecksSample
                 return Task.FromResult(HealthCheckResult.Healthy("Dependency is ready"));
             }
 
-            return Task.FromResult(HealthCheckResult.Unhealthy("Dependency is still initializing"));
+            return Task.FromResult(new HealthCheckResult(
+                status: context.Registration.FailureStatus, 
+                description: "Dependency is still initializing"));
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Diagnostics.HealthChecks/HealthCheckOptions.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics.HealthChecks/HealthCheckOptions.cs
@@ -33,9 +33,6 @@ namespace Microsoft.AspNetCore.Diagnostics.HealthChecks
             { HealthStatus.Healthy, StatusCodes.Status200OK },
             { HealthStatus.Degraded, StatusCodes.Status200OK },
             { HealthStatus.Unhealthy, StatusCodes.Status503ServiceUnavailable },
-
-            // This means that a health check failed, so 500 is appropriate. This is an error.
-            { HealthStatus.Failed, StatusCodes.Status500InternalServerError },
         };
 
         /// <summary>

--- a/src/Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions/HealthCheckResult.cs
+++ b/src/Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions/HealthCheckResult.cs
@@ -14,16 +14,16 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
         private static readonly IReadOnlyDictionary<string, object> _emptyReadOnlyDictionary = new Dictionary<string, object>();
 
         /// <summary>
-        /// Creates a new <see cref="HealthCheckResult"/> with the specified values for <paramref name="result"/>, <paramref name="exception"/>,
-        /// <paramref name="description"/>, and <paramref name="data"/>.
+        /// Creates a new <see cref="HealthCheckResult"/> with the specified values for <paramref name="status"/>, 
+        /// <paramref name="exception"/>, <paramref name="description"/>, and <paramref name="data"/>.
         /// </summary>
-        /// <param name="result">A value indicating the pass/fail status of the component that was checked.</param>
+        /// <param name="status">A value indicating the pass/fail status of the component that was checked.</param>
         /// <param name="description">A human-readable description of the status of the component that was checked.</param>
         /// <param name="exception">An <see cref="Exception"/> representing the exception that was thrown when checking for status (if any).</param>
         /// <param name="data">Additional key-value pairs describing the health of the component.</param>
-        public HealthCheckResult(bool result, string description, Exception exception, IReadOnlyDictionary<string, object> data)
+        public HealthCheckResult(HealthStatus status, string description, Exception exception, IReadOnlyDictionary<string, object> data)
         {
-            Result = result;
+            Status = status;
             Description = description;
             Exception = exception;
             Data = data ?? _emptyReadOnlyDictionary;
@@ -49,7 +49,7 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
         /// is considered to have passed health validation. A <c>false</c> value will be mapped to the configured 
         /// <see cref="HealthStatus"/> by  the health check system.
         /// </summary>
-        public bool Result { get; }
+        public HealthStatus Status { get; }
 
         /// <summary>
         /// Creates a <see cref="HealthCheckResult"/> representing a passing component.
@@ -57,10 +57,24 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
         /// <returns>A <see cref="HealthCheckResult"/> representing a passing component.</returns>
         /// <param name="description">A human-readable description of the status of the component that was checked. Optional.</param>
         /// <param name="data">Additional key-value pairs describing the health of the component. Optional.</param>
-        public static HealthCheckResult Passed(string description = null, IReadOnlyDictionary<string, object> data = null)
+        public static HealthCheckResult Healthy(string description = null, IReadOnlyDictionary<string, object> data = null)
         {
-            return new HealthCheckResult(result: true, description, exception: null, data);
+            return new HealthCheckResult(status: HealthStatus.Healthy, description, exception: null, data);
         }
+
+
+        /// <summary>
+        /// Creates a <see cref="HealthCheckResult"/> representing a degrated component.
+        /// </summary>
+        /// <param name="description">A human-readable description of the status of the component that was checked. Optional.</param>
+        /// <param name="exception">An <see cref="Exception"/> representing the exception that was thrown when checking for status. Optional.</param>
+        /// <param name="data">Additional key-value pairs describing the health of the component. Optional.</param>
+        /// <returns>A <see cref="HealthCheckResult"/> representing a degraged component.</returns>
+        public static HealthCheckResult Degraded(string description = null, Exception exception = null, IReadOnlyDictionary<string, object> data = null)
+        {
+            return new HealthCheckResult(status: HealthStatus.Degraded, description, exception: null, data);
+        }
+
 
         /// <summary>
         /// Creates a <see cref="HealthCheckResult"/> representing an failing component.
@@ -69,9 +83,9 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
         /// <param name="exception">An <see cref="Exception"/> representing the exception that was thrown when checking for status. Optional.</param>
         /// <param name="data">Additional key-value pairs describing the health of the component. Optional.</param>
         /// <returns>A <see cref="HealthCheckResult"/> representing an failing component.</returns>
-        public static HealthCheckResult Failed(string description = null, Exception exception = null, IReadOnlyDictionary<string, object> data = null)
+        public static HealthCheckResult Unhealthy(string description = null, Exception exception = null, IReadOnlyDictionary<string, object> data = null)
         {
-            return new HealthCheckResult(result: false, description, exception, data);
+            return new HealthCheckResult(status: HealthStatus.Unhealthy, description, exception, data);
         }
     }
 }

--- a/src/Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions/HealthCheckResult.cs
+++ b/src/Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions/HealthCheckResult.cs
@@ -17,11 +17,11 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
         /// Creates a new <see cref="HealthCheckResult"/> with the specified values for <paramref name="status"/>, 
         /// <paramref name="exception"/>, <paramref name="description"/>, and <paramref name="data"/>.
         /// </summary>
-        /// <param name="status">A value indicating the pass/fail status of the component that was checked.</param>
+        /// <param name="status">A value indicating the status of the component that was checked.</param>
         /// <param name="description">A human-readable description of the status of the component that was checked.</param>
         /// <param name="exception">An <see cref="Exception"/> representing the exception that was thrown when checking for status (if any).</param>
         /// <param name="data">Additional key-value pairs describing the health of the component.</param>
-        public HealthCheckResult(HealthStatus status, string description, Exception exception, IReadOnlyDictionary<string, object> data)
+        public HealthCheckResult(HealthStatus status, string description = null, Exception exception = null, IReadOnlyDictionary<string, object> data = null)
         {
             Status = status;
             Description = description;
@@ -45,18 +45,16 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
         public Exception Exception { get; }
 
         /// <summary>
-        /// Gets a value indicating the pass/fail status of the component that was checked. If <c>true</c>, then the component 
-        /// is considered to have passed health validation. A <c>false</c> value will be mapped to the configured 
-        /// <see cref="HealthStatus"/> by  the health check system.
+        /// Gets a value indicating the status of the component that was checked.
         /// </summary>
         public HealthStatus Status { get; }
 
         /// <summary>
-        /// Creates a <see cref="HealthCheckResult"/> representing a passing component.
+        /// Creates a <see cref="HealthCheckResult"/> representing a healthy component.
         /// </summary>
-        /// <returns>A <see cref="HealthCheckResult"/> representing a passing component.</returns>
         /// <param name="description">A human-readable description of the status of the component that was checked. Optional.</param>
         /// <param name="data">Additional key-value pairs describing the health of the component. Optional.</param>
+        /// <returns>A <see cref="HealthCheckResult"/> representing a healthy component.</returns>
         public static HealthCheckResult Healthy(string description = null, IReadOnlyDictionary<string, object> data = null)
         {
             return new HealthCheckResult(status: HealthStatus.Healthy, description, exception: null, data);
@@ -64,7 +62,7 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
 
 
         /// <summary>
-        /// Creates a <see cref="HealthCheckResult"/> representing a degrated component.
+        /// Creates a <see cref="HealthCheckResult"/> representing a degraded component.
         /// </summary>
         /// <param name="description">A human-readable description of the status of the component that was checked. Optional.</param>
         /// <param name="exception">An <see cref="Exception"/> representing the exception that was thrown when checking for status. Optional.</param>
@@ -75,14 +73,13 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
             return new HealthCheckResult(status: HealthStatus.Degraded, description, exception: null, data);
         }
 
-
         /// <summary>
-        /// Creates a <see cref="HealthCheckResult"/> representing an failing component.
+        /// Creates a <see cref="HealthCheckResult"/> representing an unhealthy component.
         /// </summary>
         /// <param name="description">A human-readable description of the status of the component that was checked. Optional.</param>
         /// <param name="exception">An <see cref="Exception"/> representing the exception that was thrown when checking for status. Optional.</param>
         /// <param name="data">Additional key-value pairs describing the health of the component. Optional.</param>
-        /// <returns>A <see cref="HealthCheckResult"/> representing an failing component.</returns>
+        /// <returns>A <see cref="HealthCheckResult"/> representing an unhealthy component.</returns>
         public static HealthCheckResult Unhealthy(string description = null, Exception exception = null, IReadOnlyDictionary<string, object> data = null)
         {
             return new HealthCheckResult(status: HealthStatus.Unhealthy, description, exception, data);

--- a/src/Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions/HealthReport.cs
+++ b/src/Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions/HealthReport.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
                     currentValue = entry.Status;
                 }
 
-                if (currentValue == HealthStatus.Failed)
+                if (currentValue == HealthStatus.Unhealthy)
                 {
                     // Game over, man! Game over!
                     // (We hit the worst possible status, so there's no need to keep iterating)

--- a/src/Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions/HealthReportEntry.cs
+++ b/src/Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions/HealthReportEntry.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
 
         /// <summary>
         /// Gets the health status of the component that was checked. The <see cref="Status"/> is based on the pass/fail value of
-        /// <see cref="HealthCheckResult.Passed"/> and the configured value of <see cref="HealthCheckRegistration.FailureStatus"/>.
+        /// <see cref="HealthCheckResult.Healthy"/> and the configured value of <see cref="HealthCheckRegistration.FailureStatus"/>.
         /// </summary>
         public HealthStatus Status { get; }
     }

--- a/src/Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions/HealthReportEntry.cs
+++ b/src/Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions/HealthReportEntry.cs
@@ -52,8 +52,7 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
         public Exception Exception { get; }
 
         /// <summary>
-        /// Gets the health status of the component that was checked. The <see cref="Status"/> is based on the pass/fail value of
-        /// <see cref="HealthCheckResult.Healthy"/> and the configured value of <see cref="HealthCheckRegistration.FailureStatus"/>.
+        /// Gets the health status of the component that was checked.
         /// </summary>
         public HealthStatus Status { get; }
     }

--- a/src/Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions/HealthStatus.cs
+++ b/src/Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions/HealthStatus.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
     /// </summary>
     /// <remarks>
     /// <para>
-    /// A health status is derived the pass/fail result of an <see cref="IHealthCheck"/> (<see cref="HealthCheckResult.Result"/>)
+    /// A health status is derived the pass/fail result of an <see cref="IHealthCheck"/> (<see cref="HealthCheckResult.Status"/>)
     /// and the corresponding value of <see cref="HealthCheckRegistration.FailureStatus"/>.
     /// </para>
     /// <para>
@@ -23,23 +23,19 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
     public enum HealthStatus
     {
         /// <summary>
-        /// Indicates that an unexpected exception was thrown when running the health check.
+        /// Indicates that the health check determined that the component was unhealthy, or an unhandled
+        /// exception was thrown while executing the health check.
         /// </summary>
-        Failed = 0,
-
-        /// <summary>
-        /// Indicates that the health check determined that the component was unhealthy.
-        /// </summary>
-        Unhealthy = 1,
+        Unhealthy = 0,
 
         /// <summary>
         /// Indicates that the health check determined that the component was in a degraded state.
         /// </summary>
-        Degraded = 2,
+        Degraded = 1,
 
         /// <summary>
         /// Indicates that the health check determined that the component was healthy.
         /// </summary>
-        Healthy = 3,
+        Healthy = 2,
     }
 }

--- a/src/Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions/HealthStatus.cs
+++ b/src/Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions/HealthStatus.cs
@@ -8,10 +8,6 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
     /// </summary>
     /// <remarks>
     /// <para>
-    /// A health status is derived the pass/fail result of an <see cref="IHealthCheck"/> (<see cref="HealthCheckResult.Status"/>)
-    /// and the corresponding value of <see cref="HealthCheckRegistration.FailureStatus"/>.
-    /// </para>
-    /// <para>
     /// A status of <see cref="Unhealthy"/> should be considered the default value for a failing health check. Application
     /// developers may configure a health check to report a different status as desired.
     /// </para>

--- a/src/Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore/DbContextHealthCheck.cs
+++ b/src/Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore/DbContextHealthCheck.cs
@@ -47,10 +47,10 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
 
             if (await testQuery(_dbContext, cancellationToken))
             {
-                return HealthCheckResult.Passed();
+                return HealthCheckResult.Healthy();
             }
 
-            return HealthCheckResult.Failed();
+            return HealthCheckResult.Unhealthy();
         }
     }
 }

--- a/src/Microsoft.Extensions.Diagnostics.HealthChecks/DefaultHealthCheckService.cs
+++ b/src/Microsoft.Extensions.Diagnostics.HealthChecks/DefaultHealthCheckService.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
                             var duration = stopwatch.GetElapsedTime();
 
                             entry = new HealthReportEntry(
-                                status: result.Result ? HealthStatus.Healthy : registration.FailureStatus,
+                                status: result.Status,
                                 description: result.Description,
                                 duration: duration,
                                 exception: result.Exception,
@@ -91,7 +91,7 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
                         {
                             var duration = stopwatch.GetElapsedTime();
                             entry = new HealthReportEntry(
-                                status: HealthStatus.Failed,
+                                status: HealthStatus.Unhealthy,
                                 description: ex.Message,
                                 duration: duration,
                                 exception: ex,
@@ -211,10 +211,6 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
 
                     case HealthStatus.Unhealthy:
                         _healthCheckEndUnhealthy(logger, registration.Name, duration.TotalMilliseconds, entry.Status, entry.Description, null);
-                        break;
-
-                    case HealthStatus.Failed:
-                        _healthCheckEndFailed(logger, registration.Name, duration.TotalMilliseconds, entry.Status, entry.Description, null);
                         break;
                 }
             }

--- a/src/Microsoft.Extensions.Diagnostics.HealthChecks/DependencyInjection/HealthChecksBuilderDelegateExtensions.cs
+++ b/src/Microsoft.Extensions.Diagnostics.HealthChecks/DependencyInjection/HealthChecksBuilderDelegateExtensions.cs
@@ -19,10 +19,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
         /// <param name="name">The name of the health check.</param>
-        /// <param name="failureStatus">
-        /// The <see cref="HealthStatus"/> that should be reported when the health check reports a failure. If the provided value
-        /// is <c>null</c>, then <see cref="HealthStatus.Unhealthy"/> will be reported.
-        /// </param>
         /// <param name="tags">A list of tags that can be used to filter health checks.</param>
         /// <param name="check">A delegate that provides the health check implementation.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
@@ -30,7 +26,6 @@ namespace Microsoft.Extensions.DependencyInjection
             this IHealthChecksBuilder builder,
             string name,
             Func<HealthCheckResult> check,
-            HealthStatus? failureStatus = null,
             IEnumerable<string> tags = null)
         {
             if (builder == null)
@@ -49,7 +44,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             var instance = new DelegateHealthCheck((ct) => Task.FromResult(check()));
-            return builder.Add(new HealthCheckRegistration(name, instance, failureStatus, tags));
+            return builder.Add(new HealthCheckRegistration(name, instance, failureStatus: null, tags));
         }
 
         /// <summary>
@@ -57,10 +52,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
         /// <param name="name">The name of the health check.</param>
-        /// <param name="failureStatus">
-        /// The <see cref="HealthStatus"/> that should be reported when the health check reports a failure. If the provided value
-        /// is <c>null</c>, then <see cref="HealthStatus.Unhealthy"/> will be reported.
-        /// </param>
         /// <param name="tags">A list of tags that can be used to filter health checks.</param>
         /// <param name="check">A delegate that provides the health check implementation.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
@@ -68,7 +59,6 @@ namespace Microsoft.Extensions.DependencyInjection
             this IHealthChecksBuilder builder,
             string name,
             Func<CancellationToken, HealthCheckResult> check,
-            HealthStatus? failureStatus = null,
             IEnumerable<string> tags = null)
         {
             if (builder == null)
@@ -87,7 +77,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             var instance = new DelegateHealthCheck((ct) => Task.FromResult(check(ct)));
-            return builder.Add(new HealthCheckRegistration(name, instance, failureStatus, tags));
+            return builder.Add(new HealthCheckRegistration(name, instance, failureStatus: null, tags));
         }
 
         /// <summary>
@@ -95,10 +85,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
         /// <param name="name">The name of the health check.</param>
-        /// <param name="failureStatus">
-        /// The <see cref="HealthStatus"/> that should be reported when the health check reports a failure. If the provided value
-        /// is <c>null</c>, then <see cref="HealthStatus.Unhealthy"/> will be reported.
-        /// </param>
         /// <param name="tags">A list of tags that can be used to filter health checks.</param>
         /// <param name="check">A delegate that provides the health check implementation.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
@@ -106,7 +92,6 @@ namespace Microsoft.Extensions.DependencyInjection
             this IHealthChecksBuilder builder,
             string name,
             Func<Task<HealthCheckResult>> check,
-            HealthStatus? failureStatus = null,
             IEnumerable<string> tags = null)
         {
             if (builder == null)
@@ -125,7 +110,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             var instance = new DelegateHealthCheck((ct) => check());
-            return builder.Add(new HealthCheckRegistration(name, instance, failureStatus, tags));
+            return builder.Add(new HealthCheckRegistration(name, instance, failureStatus: null, tags));
         }
 
         /// <summary>
@@ -133,10 +118,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
         /// <param name="name">The name of the health check.</param>
-        /// <param name="failureStatus">
-        /// The <see cref="HealthStatus"/> that should be reported when the health check reports a failure. If the provided value
-        /// is <c>null</c>, then <see cref="HealthStatus.Unhealthy"/> will be reported.
-        /// </param>
         /// <param name="tags">A list of tags that can be used to filter health checks.</param>
         /// <param name="check">A delegate that provides the health check implementation.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
@@ -144,7 +125,6 @@ namespace Microsoft.Extensions.DependencyInjection
             this IHealthChecksBuilder builder,
             string name,
             Func<CancellationToken, Task<HealthCheckResult>> check,
-            HealthStatus? failureStatus = null,
             IEnumerable<string> tags = null)
         {
             if (builder == null)
@@ -163,7 +143,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             var instance = new DelegateHealthCheck((ct) => check(ct));
-            return builder.Add(new HealthCheckRegistration(name, instance, failureStatus, tags));
+            return builder.Add(new HealthCheckRegistration(name, instance, failureStatus: null, tags));
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Diagnostics.HealthChecks.Tests/HealthCheckMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.Diagnostics.HealthChecks.Tests/HealthCheckMiddlewareTests.cs
@@ -110,9 +110,9 @@ namespace Microsoft.AspNetCore.Diagnostics.HealthChecks
                 .ConfigureServices(services =>
                 {
                     services.AddHealthChecks()
-                        .AddCheck("Foo", () => HealthCheckResult.Passed("A-ok!"))
-                        .AddCheck("Bar", () => HealthCheckResult.Passed("A-ok!"))
-                        .AddCheck("Baz", () => HealthCheckResult.Passed("A-ok!"));
+                        .AddCheck("Foo", () => HealthCheckResult.Healthy("A-ok!"))
+                        .AddCheck("Bar", () => HealthCheckResult.Healthy("A-ok!"))
+                        .AddCheck("Baz", () => HealthCheckResult.Healthy("A-ok!"));
                 });
             var server = new TestServer(builder);
             var client = server.CreateClient();
@@ -135,9 +135,9 @@ namespace Microsoft.AspNetCore.Diagnostics.HealthChecks
                 .ConfigureServices(services =>
                 {
                     services.AddHealthChecks()
-                        .AddCheck("Foo", () => HealthCheckResult.Passed("A-ok!"))
-                        .AddCheck("Bar", () => HealthCheckResult.Failed("Not so great."), failureStatus: HealthStatus.Degraded)
-                        .AddCheck("Baz", () => HealthCheckResult.Passed("A-ok!"));
+                        .AddCheck("Foo", () => HealthCheckResult.Healthy("A-ok!"))
+                        .AddCheck("Bar", () => HealthCheckResult.Degraded("Not so great."))
+                        .AddCheck("Baz", () => HealthCheckResult.Healthy("A-ok!"));
                 });
             var server = new TestServer(builder);
             var client = server.CreateClient();
@@ -160,9 +160,9 @@ namespace Microsoft.AspNetCore.Diagnostics.HealthChecks
                 .ConfigureServices(services =>
                 {
                     services.AddHealthChecks()
-                        .AddAsyncCheck("Foo", () => Task.FromResult(HealthCheckResult.Passed("A-ok!")))
-                        .AddAsyncCheck("Bar", () => Task.FromResult(HealthCheckResult.Failed("Pretty bad.")))
-                        .AddAsyncCheck("Baz", () => Task.FromResult(HealthCheckResult.Passed("A-ok!")));
+                        .AddAsyncCheck("Foo", () => Task.FromResult(HealthCheckResult.Healthy("A-ok!")))
+                        .AddAsyncCheck("Bar", () => Task.FromResult(HealthCheckResult.Unhealthy("Pretty bad.")))
+                        .AddAsyncCheck("Baz", () => Task.FromResult(HealthCheckResult.Healthy("A-ok!")));
                 });
             var server = new TestServer(builder);
             var client = server.CreateClient();
@@ -175,7 +175,7 @@ namespace Microsoft.AspNetCore.Diagnostics.HealthChecks
         }
 
         [Fact]
-        public async Task StatusCodeIs500IfCheckIsFailed()
+        public async Task StatusCodeIs503IfCheckHasUnhandledException()
         {
             var builder = new WebHostBuilder()
                 .Configure(app =>
@@ -185,18 +185,18 @@ namespace Microsoft.AspNetCore.Diagnostics.HealthChecks
                 .ConfigureServices(services =>
                 {
                     services.AddHealthChecks()
-                        .AddAsyncCheck("Foo", () => Task.FromResult(HealthCheckResult.Passed("A-ok!")))
+                        .AddAsyncCheck("Foo", () => Task.FromResult(HealthCheckResult.Healthy("A-ok!")))
                         .AddAsyncCheck("Bar", () => throw null)
-                        .AddAsyncCheck("Baz", () => Task.FromResult(HealthCheckResult.Passed("A-ok!")));
+                        .AddAsyncCheck("Baz", () => Task.FromResult(HealthCheckResult.Healthy("A-ok!")));
                 });
             var server = new TestServer(builder);
             var client = server.CreateClient();
 
             var response = await client.GetAsync("/health");
 
-            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
             Assert.Equal("text/plain", response.Content.Headers.ContentType.ToString());
-            Assert.Equal("Failed", await response.Content.ReadAsStringAsync());
+            Assert.Equal("Unhealthy", await response.Content.ReadAsStringAsync());
         }
 
         [Fact]
@@ -223,9 +223,9 @@ namespace Microsoft.AspNetCore.Diagnostics.HealthChecks
                 .ConfigureServices(services =>
                 {
                     services.AddHealthChecks()
-                        .AddAsyncCheck("Foo", () => Task.FromResult(HealthCheckResult.Passed("A-ok!")))
-                        .AddAsyncCheck("Bar", () => Task.FromResult(HealthCheckResult.Failed("Pretty bad.")))
-                        .AddAsyncCheck("Baz", () => Task.FromResult(HealthCheckResult.Passed("A-ok!")));
+                        .AddAsyncCheck("Foo", () => Task.FromResult(HealthCheckResult.Healthy("A-ok!")))
+                        .AddAsyncCheck("Bar", () => Task.FromResult(HealthCheckResult.Unhealthy("Pretty bad.")))
+                        .AddAsyncCheck("Baz", () => Task.FromResult(HealthCheckResult.Healthy("A-ok!")));
                 });
             var server = new TestServer(builder);
             var client = server.CreateClient();
@@ -252,9 +252,9 @@ namespace Microsoft.AspNetCore.Diagnostics.HealthChecks
                 .ConfigureServices(services =>
                 {
                     services.AddHealthChecks()
-                        .AddAsyncCheck("Foo", () => Task.FromResult(HealthCheckResult.Passed("A-ok!")))
-                        .AddAsyncCheck("Bar", () => Task.FromResult(HealthCheckResult.Failed("Pretty bad.")))
-                        .AddAsyncCheck("Baz", () => Task.FromResult(HealthCheckResult.Passed("A-ok!")));
+                        .AddAsyncCheck("Foo", () => Task.FromResult(HealthCheckResult.Healthy("A-ok!")))
+                        .AddAsyncCheck("Bar", () => Task.FromResult(HealthCheckResult.Unhealthy("Pretty bad.")))
+                        .AddAsyncCheck("Baz", () => Task.FromResult(HealthCheckResult.Healthy("A-ok!")));
                 });
             var server = new TestServer(builder);
             var client = server.CreateClient();
@@ -357,10 +357,10 @@ namespace Microsoft.AspNetCore.Diagnostics.HealthChecks
                 .ConfigureServices(services =>
                 {
                     services.AddHealthChecks()
-                        .AddAsyncCheck("Foo", () => Task.FromResult(HealthCheckResult.Passed("A-ok!")))
+                        .AddAsyncCheck("Foo", () => Task.FromResult(HealthCheckResult.Healthy("A-ok!")))
                         // Will get filtered out
-                        .AddAsyncCheck("Bar", () => Task.FromResult(HealthCheckResult.Failed("A-ok!")))
-                        .AddAsyncCheck("Baz", () => Task.FromResult(HealthCheckResult.Passed("A-ok!")));
+                        .AddAsyncCheck("Bar", () => Task.FromResult(HealthCheckResult.Unhealthy("A-ok!")))
+                        .AddAsyncCheck("Baz", () => Task.FromResult(HealthCheckResult.Healthy("A-ok!")));
                 });
             var server = new TestServer(builder);
             var client = server.CreateClient();

--- a/test/Microsoft.Extensions.Diagnostics.HealthChecks.Tests/DependencyInjection/HealthChecksBuilderTest.cs
+++ b/test/Microsoft.Extensions.Diagnostics.HealthChecks.Tests/DependencyInjection/HealthChecksBuilderTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.DependencyInjection
             // Arrange
             var instance = new DelegateHealthCheck((_) =>
             {
-                return Task.FromResult(HealthCheckResult.Passed());
+                return Task.FromResult(HealthCheckResult.Healthy());
             });
 
             var services = CreateServices();
@@ -112,9 +112,9 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             // Arrange
             var services = CreateServices();
-            services.AddHealthChecks().AddCheck("test", failureStatus: HealthStatus.Degraded, tags: new[] { "tag", }, check: () =>
+            services.AddHealthChecks().AddCheck("test", tags: new[] { "tag", }, check: () =>
             {
-                return HealthCheckResult.Passed();
+                return HealthCheckResult.Healthy();
             });
 
             var serviceProvider = services.BuildServiceProvider();
@@ -125,7 +125,7 @@ namespace Microsoft.Extensions.DependencyInjection
             // Assert
             var registration = Assert.Single(options.Registrations);
             Assert.Equal("test", registration.Name);
-            Assert.Equal(HealthStatus.Degraded, registration.FailureStatus);
+            Assert.Equal(HealthStatus.Unhealthy, registration.FailureStatus);
             Assert.Equal<string>(new[] { "tag", }, registration.Tags);
             Assert.IsType<DelegateHealthCheck>(registration.Factory(serviceProvider));
         }
@@ -137,8 +137,8 @@ namespace Microsoft.Extensions.DependencyInjection
             var services = CreateServices();
             services.AddHealthChecks().AddCheck("test", (_) =>
             {
-                return HealthCheckResult.Passed();
-            }, failureStatus: HealthStatus.Degraded, tags: new[] { "tag", });
+                return HealthCheckResult.Degraded();
+            }, tags: new[] { "tag", });
 
             var serviceProvider = services.BuildServiceProvider();
 
@@ -148,7 +148,7 @@ namespace Microsoft.Extensions.DependencyInjection
             // Assert
             var registration = Assert.Single(options.Registrations);
             Assert.Equal("test", registration.Name);
-            Assert.Equal(HealthStatus.Degraded, registration.FailureStatus);
+            Assert.Equal(HealthStatus.Unhealthy, registration.FailureStatus);
             Assert.Equal<string>(new[] { "tag", }, registration.Tags);
             Assert.IsType<DelegateHealthCheck>(registration.Factory(serviceProvider));
         }
@@ -160,8 +160,8 @@ namespace Microsoft.Extensions.DependencyInjection
             var services = CreateServices();
             services.AddHealthChecks().AddAsyncCheck("test", () =>
             {
-                return Task.FromResult(HealthCheckResult.Passed());
-            }, failureStatus: HealthStatus.Degraded, tags: new[] { "tag", });
+                return Task.FromResult(HealthCheckResult.Healthy());
+            }, tags: new[] { "tag", });
 
             var serviceProvider = services.BuildServiceProvider();
 
@@ -171,7 +171,7 @@ namespace Microsoft.Extensions.DependencyInjection
             // Assert
             var registration = Assert.Single(options.Registrations);
             Assert.Equal("test", registration.Name);
-            Assert.Equal(HealthStatus.Degraded, registration.FailureStatus);
+            Assert.Equal(HealthStatus.Unhealthy, registration.FailureStatus);
             Assert.Equal<string>(new[] { "tag", }, registration.Tags);
             Assert.IsType<DelegateHealthCheck>(registration.Factory(serviceProvider));
         }
@@ -183,8 +183,8 @@ namespace Microsoft.Extensions.DependencyInjection
             var services = CreateServices();
             services.AddHealthChecks().AddAsyncCheck("test", (_) =>
             {
-                return Task.FromResult(HealthCheckResult.Passed());
-            }, failureStatus: HealthStatus.Degraded, tags: new[] { "tag", });
+                return Task.FromResult(HealthCheckResult.Unhealthy());
+            }, tags: new[] { "tag", });
 
             var serviceProvider = services.BuildServiceProvider();
 
@@ -194,7 +194,7 @@ namespace Microsoft.Extensions.DependencyInjection
             // Assert
             var registration = Assert.Single(options.Registrations);
             Assert.Equal("test", registration.Name);
-            Assert.Equal(HealthStatus.Degraded, registration.FailureStatus);
+            Assert.Equal(HealthStatus.Unhealthy, registration.FailureStatus);
             Assert.Equal<string>(new[] { "tag", }, registration.Tags);
             Assert.IsType<DelegateHealthCheck>(registration.Factory(serviceProvider));
         }
@@ -205,10 +205,10 @@ namespace Microsoft.Extensions.DependencyInjection
             var services = new ServiceCollection();
             services
                 .AddHealthChecks()
-                .AddAsyncCheck("Foo", () => Task.FromResult(HealthCheckResult.Passed()));
+                .AddAsyncCheck("Foo", () => Task.FromResult(HealthCheckResult.Healthy()));
             services
                 .AddHealthChecks()
-                .AddAsyncCheck("Bar", () => Task.FromResult(HealthCheckResult.Passed()));
+                .AddAsyncCheck("Bar", () => Task.FromResult(HealthCheckResult.Healthy()));
 
             // Act
             var options = services.BuildServiceProvider().GetRequiredService<IOptions<HealthCheckServiceOptions>>();

--- a/test/Microsoft.Extensions.Diagnostics.HealthChecks.Tests/HealthCheckPublisherHostedServiceTest.cs
+++ b/test/Microsoft.Extensions.Diagnostics.HealthChecks.Tests/HealthCheckPublisherHostedServiceTest.cs
@@ -448,8 +448,8 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
             serviceCollection.AddOptions();
             serviceCollection.AddLogging();
             serviceCollection.AddHealthChecks()
-                .AddCheck("one", () => { return HealthCheckResult.Passed(); })
-                .AddCheck("two", () => { return HealthCheckResult.Passed(); });
+                .AddCheck("one", () => { return HealthCheckResult.Healthy(); })
+                .AddCheck("two", () => { return HealthCheckResult.Healthy(); });
 
             // Choosing big values for tests to make sure that we're not dependent on the defaults.
             // All of the tests that rely on the timer will set their own values for speed.

--- a/test/Microsoft.Extensions.Diagnostics.HealthChecks.Tests/HealthReportTest.cs
+++ b/test/Microsoft.Extensions.Diagnostics.HealthChecks.Tests/HealthReportTest.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
         [InlineData(HealthStatus.Healthy)]
         [InlineData(HealthStatus.Degraded)]
         [InlineData(HealthStatus.Unhealthy)]
-        [InlineData(HealthStatus.Failed)]
         public void Status_MatchesWorstStatusInResults(HealthStatus status)
         {
             var result = new HealthReport(new Dictionary<string, HealthReportEntry>()


### PR DESCRIPTION
This change brings back the ability to return Healthy/Degraded/Unhealthy
in a HealthCheckResult. We tried making this pass/fail in 2.2.0-preview3
and folks writing health checks for their own use pointed out (rightly
so) that it was too limited.

It's still possible for the app developer to configure the failure
status of a health check, but it requires the health check author to
cooperate.

I also got rid of HealthStatus.Failed since it raises more questions
than it answers. It's really not clear that it's valuable for a health
check for behave different when throwing an unhandled exception.

We would still recommend that a health check library handle exceptions
that they know about and return `context.Registration.FailureStatus`.